### PR TITLE
Add no_std compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,6 @@ harness = false
 name = "crit_bench"
 path = "benches/crit_bench.rs"
 
-[dependencies]
-quick-error = "1.2.3"
-
 [dev-dependencies]
 criterion = "0.3.3"
 lz4 = "1.23.1"
@@ -29,10 +26,11 @@ more-asserts = "0.2.1"
 git = "https://github.com/main--/rust-lz-fear"
 
 [features]
-default = ["safe-encode", "safe-decode"]
+default = ["std", "safe-encode", "safe-decode"]
 safe-decode = []
 safe-encode = []
 checked-decode = []
+std = []
 
 [profile.bench]
 codegen-units = 1

--- a/src/block/compress.rs
+++ b/src/block/compress.rs
@@ -571,25 +571,4 @@ mod tests {
         ];
         let _out = compress(&input);
     }
-
-    #[test]
-    #[cfg_attr(miri, ignore)]
-    fn test_compare() {
-        let mut input: &[u8] = &[10, 12, 14, 16];
-
-        let mut cache = vec![];
-        let mut encoder = lz4::EncoderBuilder::new()
-            .level(2)
-            .build(&mut cache)
-            .unwrap();
-        // let mut read = *input;
-        std::io::copy(&mut input, &mut encoder).unwrap();
-        let (comp_lz4, _result) = encoder.finish();
-
-        println!("{:?}", comp_lz4);
-
-        let input: &[u8] = &[10, 12, 14, 16];
-        let out = compress(&input);
-        dbg!(&out);
-    }
 }

--- a/src/block/compress.rs
+++ b/src/block/compress.rs
@@ -25,7 +25,6 @@ pub fn hash(sequence: u32) -> u32 {
     (sequence.wrapping_mul(2654435761_u32)) >> 16
 }
 
- 
 /// hashes and right shifts to a maximum value of 16bit, 65535
 /// The right shift is done in order to not exceed, the hashtables capacity
 pub fn hash5(sequence: usize) -> u32 {
@@ -71,9 +70,10 @@ fn get_batch_arch(input: &[u8], n: usize) -> usize {
 
 #[inline]
 fn get_hash_at(input: &[u8], pos: usize) -> usize {
-    if input.len() < u16::MAX as usize { // add if usize === 8
+    if input.len() < u16::MAX as usize {
+        // add if usize === 8
         hash(get_batch(input, pos)) as usize
-    }else{
+    } else {
         hash5(get_batch_arch(input, pos)) as usize
     }
 }

--- a/src/block/decompress_safe.rs
+++ b/src/block/decompress_safe.rs
@@ -1,6 +1,7 @@
 //! The decompression algorithm.
 
 use crate::block::DecompressError;
+use alloc::vec::Vec;
 
 /// Read an integer LSIC (linear small integer code) encoded.
 ///

--- a/src/block/hashtable.rs
+++ b/src/block/hashtable.rs
@@ -9,6 +9,8 @@
 /// Every four bytes is assigned an entry. When this number is lower, fewer entries exists, and
 /// thus collisions are more likely, hurting the compression ratio.
 ///
+use alloc::vec::Vec;
+
 pub trait HashTable {
     fn get_at(&self, pos: usize) -> usize;
     fn put_at(&mut self, pos: usize, val: usize);
@@ -25,7 +27,7 @@ pub struct HashTableUsize {
 impl HashTableUsize {
     #[inline]
     pub fn new(dict_size: usize, dict_bitshift: usize) -> Self {
-        let dict = vec![0; dict_size];
+        let dict = alloc::vec![0; dict_size];
         Self {
             dict,
             dict_bitshift,
@@ -61,7 +63,7 @@ pub struct HashTableU32 {
 impl HashTableU32 {
     #[inline]
     pub fn new(dict_size: usize, dict_bitshift: usize) -> Self {
-        let dict = vec![0; dict_size];
+        let dict = alloc::vec![0; dict_size];
         Self {
             dict,
             dict_bitshift,
@@ -96,7 +98,7 @@ pub struct HashTableU16 {
 impl HashTableU16 {
     #[inline]
     pub fn new(dict_size: usize, dict_bitshift: usize) -> Self {
-        let dict = vec![0; dict_size];
+        let dict = alloc::vec![0; dict_size];
         Self {
             dict,
             dict_bitshift,

--- a/src/block/hashtable.rs
+++ b/src/block/hashtable.rs
@@ -135,4 +135,3 @@ pub fn get_table_size(input_len: usize) -> (usize, usize) {
     };
     (dict_size, dict_bitshift)
 }
-

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -1,4 +1,4 @@
-/*! 
+/*!
 
 <https://github.com/lz4/lz4/blob/dev/doc/lz4_Block_format.md>
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,14 +18,18 @@ assert_eq!(input, uncompressed);
 - `safe-encode` uses only safe rust for encode. _enabled by default_
 - `safe-decode` uses only safe rust for encode. _enabled by default_
 - `checked-decode` will add aditional checks if `safe-decode` is not enabled, to avoid out of bounds access
+- `std` enables dependency on the standard library. _enabled by default_
 
 For maximum performance use `no-default-features`.
 
 */
-#[macro_use]
-extern crate quick_error;
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 pub mod block;
+#[cfg(feature = "std")]
 mod frame;
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,12 +31,6 @@ extern crate alloc;
 pub mod block;
 #[cfg(feature = "std")]
 mod frame;
-#[cfg(test)]
-mod tests;
-
-#[cfg(test)]
-#[macro_use]
-extern crate more_asserts;
 
 pub use block::compress::{compress, compress_into, compress_prepend_size};
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -241,7 +241,6 @@ fn small_compressible_2() {
 #[test]
 fn small_compressible_3() {
     compress("AAAAAAAAAAAZZZZZZZZAAAAAAAA".as_bytes());
-
 }
 // #[test]
 // fn compare_small_compressible() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,12 +1,14 @@
 //! Tests.
 
+#[macro_use]
+extern crate more_asserts;
 // extern crate test;
 
 // use crate::block::compress::compress_into_2;
-use crate::block::{compress_prepend_size, decompress_size_prepended};
-use crate::{compress, decompress};
 use lz4::block::{compress as lz4_cpp_block_compress, decompress as lz4_cpp_block_decompress};
 use lz4_compress::compress as lz4_rust_compress;
+use lz4_flex::block::{compress_prepend_size, decompress_size_prepended};
+use lz4_flex::{compress, decompress};
 use std::str;
 
 const COMPRESSION1K: &'static [u8] = include_bytes!("../benches/compression_1k.txt");
@@ -393,4 +395,25 @@ mod test_compression {
             );
         }
     }
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn test_compare_compress() {
+    let mut input: &[u8] = &[10, 12, 14, 16];
+
+    let mut cache = vec![];
+    let mut encoder = lz4::EncoderBuilder::new()
+        .level(2)
+        .build(&mut cache)
+        .unwrap();
+    // let mut read = *input;
+    std::io::copy(&mut input, &mut encoder).unwrap();
+    let (comp_lz4, _result) = encoder.finish();
+
+    println!("{:?}", comp_lz4);
+
+    let input: &[u8] = &[10, 12, 14, 16];
+    let out = compress(&input);
+    dbg!(&out);
 }


### PR DESCRIPTION
I also noticed that it doesn't compile on 32-bit targets; I think some of the stuff like read_usize_ptr assume too much about the target platform. I think probably some of the uses of `usize` should be changed to u64, which is always 8 bytes, although I'm not sure what the lz4 spec says. I tested using:

```shell
$ cargo c --target thumbv7em-none-eabi --no-default-features
```
