### PR TITLE
Bug fix 2 issues

### DIFF
--- a/src/block/compress.rs
+++ b/src/block/compress.rs
@@ -365,7 +365,7 @@ pub(crate) fn compress_internal<T: HashTable, const USE_DICT: bool>(
 
     let output_start_pos = output.pos();
     if input_pos + LZ4_MIN_LENGTH > input.len() {
-        handle_last_literals(output, input, 0);
+        handle_last_literals(output, input, input_pos);
         return Ok(output.pos() - output_start_pos);
     }
 

--- a/src/frame/compress.rs
+++ b/src/frame/compress.rs
@@ -307,9 +307,12 @@ impl<W: io::Write> FrameEncoder<W> {
                 // There's more than WINDOW_SIZE bytes of lookback adding the prefix and ext_dict.
                 // Since we have a limited buffer we must shrink ext_dict in favor of the prefix,
                 // so that we can fit up to max_block_size bytes between dst_start and ext_dict start.
-                let delta = self.ext_dict_len.min(self.src_start);
+                let delta = self
+                    .ext_dict_len
+                    .min(self.src_start + self.ext_dict_len - WINDOW_SIZE);
                 self.ext_dict_offset += delta;
                 self.ext_dict_len -= delta;
+                debug_assert!(self.src_start + self.ext_dict_len >= WINDOW_SIZE)
             }
             debug_assert!(
                 self.ext_dict_len == 0 || self.src_start + max_block_size <= self.ext_dict_offset

--- a/src/frame/decompress.rs
+++ b/src/frame/decompress.rs
@@ -188,9 +188,12 @@ impl<R: io::Read> FrameDecoder<R> {
                 // There's more than WINDOW_SIZE bytes of lookback adding the prefix and ext_dict.
                 // Since we have a limited buffer we must shrink ext_dict in favor of the prefix,
                 // so that we can fit up to max_block_size bytes between dst_start and ext_dict start.
-                let delta = self.ext_dict_len.min(self.dst_start);
+                let delta = self
+                    .ext_dict_len
+                    .min(self.dst_start + self.ext_dict_len - WINDOW_SIZE);
                 self.ext_dict_offset += delta;
                 self.ext_dict_len -= delta;
+                debug_assert!(self.dst_start + self.ext_dict_len >= WINDOW_SIZE)
             }
         } else {
             debug_assert_eq!(self.ext_dict_len, 0);


### PR DESCRIPTION
Found a couple of problems when playing with this in a project. I was unable to make good regression tests for these but I was able to modify the fuzz test in a way that it tripped into the same problems.

- input_pos must be accounted when handling small inputs
- Fix ext_dict shrinking in favor of prefix under linked block mode
- Improve frame fuzz coverage w/ non full blocks
