### PR TITLE
Expand Sink abstraction to handle/hide uninitialized data

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,12 +7,32 @@ on:
     branches: [ master ]
 
 jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
   build:
 
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -23,6 +43,8 @@ jobs:
       run: cargo test --verbose --features safe-decode
     - name: Run tests no-default-features (no safe-decode)
       run: cargo test --verbose --no-default-features --features frame
+    - name: Install cargo fuzz
+      run: cargo install cargo-fuzz
     - name: Run fuzz tests (safe)
       run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test -- -max_total_time=10 || exit 1; done
     - name: Run fuzz tests (unsafe)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,6 +35,8 @@ jobs:
         override: true
     - name: Build
       run: cargo build --verbose
+    - name: Build no-default-features
+      run: cargo build --verbose --no-default-features
     - name: Run tests
       run: cargo test
     - name: Run tests --features safe-encode

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   fmt:
-    name: Rustfmt
+    name: Rustfmt check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
           args: --all -- --check
 
   build:
-
+    name: Build and test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -43,6 +43,17 @@ jobs:
       run: cargo test --verbose --features safe-decode
     - name: Run tests no-default-features (no safe-decode)
       run: cargo test --verbose --no-default-features --features frame
+
+  fuzz:
+    name: Fuzz testing
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        override: true
     - name: Install cargo fuzz
       run: cargo install cargo-fuzz
     - name: Run fuzz tests (safe)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,6 @@ jobs:
     - name: Install cargo fuzz
       run: cargo install cargo-fuzz
     - name: Run fuzz tests (safe)
-      run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test -- -max_total_time=10 || exit 1; done
+      run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test -- -max_total_time=30 || exit 1; done
     - name: Run fuzz tests (unsafe)
-      run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test --no-default-features -- -max_total_time=10 || exit 1; done
+      run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test --no-default-features -- -max_total_time=30 || exit 1; done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,15 @@ serde_json = "1.0"
 git = "https://github.com/main--/rust-lz-fear"
 
 # Uncomment to make lz4_flex master available as lz4_flex_master
-# [dev-dependencies.lz4_flex_master]
-#rev= "eb8c2e090485dcb5ef9e0da96bf72a95023753c1" # before this PR was merged
-# git = "https://github.com/PSeitz/lz4_flex"
-# package = "lz4_flex"
-#default-features=false
+[dev-dependencies.lz4_flex_master]
+git = "https://github.com/PSeitz/lz4_flex"
+package = "lz4_flex"
+# default-features=false
+# features = ["std", "frame", "checked-decode"]
 
 [features]
 default = ["std", "safe-encode", "safe-decode", "frame"]
+# default = ["std", "frame", "checked-decode"]
 safe-decode = []
 safe-encode = []
 checked-decode = []

--- a/benches/crit_bench.rs
+++ b/benches/crit_bench.rs
@@ -24,9 +24,11 @@ const ALL: &[&[u8]] = &[
 fn compress_lz4_fear(input: &[u8]) -> Vec<u8> {
     let mut buf = Vec::new();
     if input.len() <= 0xFFFF {
-        lz_fear::raw::compress2(input, 0, &mut lz_fear::raw::U16Table::default(), &mut buf).unwrap();
+        lz_fear::raw::compress2(input, 0, &mut lz_fear::raw::U16Table::default(), &mut buf)
+            .unwrap();
     } else {
-        lz_fear::raw::compress2(input, 0, &mut lz_fear::raw::U32Table::default(), &mut buf).unwrap();
+        lz_fear::raw::compress2(input, 0, &mut lz_fear::raw::U32Table::default(), &mut buf)
+            .unwrap();
     }
     buf
 }

--- a/benches/crit_bench.rs
+++ b/benches/crit_bench.rs
@@ -4,40 +4,36 @@ extern crate criterion;
 use std::io::{Read, Write};
 
 use self::criterion::*;
-use lz_fear::raw::compress2;
-use lz_fear::raw::decompress_raw;
-use lz_fear::raw::U16Table;
-use lz_fear::raw::U32Table;
 
 const COMPRESSION1K: &'static [u8] = include_bytes!("compression_1k.txt");
 const COMPRESSION34K: &'static [u8] = include_bytes!("compression_34k.txt");
 const COMPRESSION65K: &'static [u8] = include_bytes!("compression_65k.txt");
 const COMPRESSION66K: &'static [u8] = include_bytes!("compression_66k_JSON.txt");
-//const COMPRESSION10MB: &'static [u8] = include_bytes!("dickens.txt");
-const COMPRESSION95K_VERY_GOOD_LOGO: &'static [u8] = include_bytes!("../logo.jpg");
+// const COMPRESSION10MB: &'static [u8] = include_bytes!("dickens.txt");
+// const COMPRESSION95K_VERY_GOOD_LOGO: &'static [u8] = include_bytes!("../logo.jpg");
 
 const ALL: &[&[u8]] = &[
     COMPRESSION1K as &[u8],
     COMPRESSION34K as &[u8],
     COMPRESSION65K as &[u8],
     COMPRESSION66K as &[u8],
-    //COMPRESSION10MB as &[u8],
+    // COMPRESSION10MB as &[u8],
     // COMPRESSION95K_VERY_GOOD_LOGO as &[u8],
 ];
 
 fn compress_lz4_fear(input: &[u8]) -> Vec<u8> {
     let mut buf = Vec::new();
     if input.len() <= 0xFFFF {
-        compress2(input, 0, &mut U16Table::default(), &mut buf).unwrap();
+        lz_fear::raw::compress2(input, 0, &mut lz_fear::raw::U16Table::default(), &mut buf).unwrap();
     } else {
-        compress2(input, 0, &mut U32Table::default(), &mut buf).unwrap();
+        lz_fear::raw::compress2(input, 0, &mut lz_fear::raw::U32Table::default(), &mut buf).unwrap();
     }
     buf
 }
 
 fn decompress_lz4_fear(input: &[u8]) -> Vec<u8> {
     let mut vec = Vec::new();
-    decompress_raw(input, &[], &mut vec, std::usize::MAX).unwrap();
+    lz_fear::raw::decompress_raw(input, &[], &mut vec, std::usize::MAX).unwrap();
     vec
 }
 
@@ -117,6 +113,25 @@ pub fn lz4_flex_frame_decompress(input: &[u8]) -> Result<Vec<u8>, lz4_flex::fram
     Ok(out)
 }
 
+pub fn lz4_flex_master_frame_compress_with(
+    frame_info: lz4_flex_master::frame::FrameInfo,
+    input: &[u8],
+) -> Result<Vec<u8>, lz4_flex_master::frame::Error> {
+    let buffer = Vec::new();
+    let mut enc = lz4_flex_master::frame::FrameEncoder::with_frame_info(frame_info, buffer);
+    enc.write_all(input)?;
+    Ok(enc.finish()?)
+}
+
+pub fn lz4_flex_master_frame_decompress(
+    input: &[u8],
+) -> Result<Vec<u8>, lz4_flex_master::frame::Error> {
+    let mut de = lz4_flex_master::frame::FrameDecoder::new(input);
+    let mut out = Vec::new();
+    de.read_to_end(&mut out)?;
+    Ok(out)
+}
+
 fn bench_block_compression_throughput(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Linear);
 
@@ -143,29 +158,29 @@ fn bench_block_compression_throughput(c: &mut Criterion) {
         //&input,
         //|b, i| b.iter(|| lz4_flex::block::compress_with_dict(&i, &empty_vec)),
         //);
-        //// group.bench_with_input(
-        //     BenchmarkId::new("lz4_flex_rust_master", input_bytes),
-        //     &input,
-        //     |b, i| b.iter(|| lz4_flex_master::compress(&i)),
-        // );
+        group.bench_with_input(
+            BenchmarkId::new("lz4_flex_rust_master", input_bytes),
+            &input,
+            |b, i| b.iter(|| lz4_flex_master::compress(&i)),
+        );
         // group.bench_with_input(
         //     BenchmarkId::new("lz4_redox_rust", input_bytes),
         //     &input,
         //     |b, i| b.iter(|| lz4_compress::compress(&i)),
         // );
-        group.bench_with_input(
-            BenchmarkId::new("lz4_fear_rust", input_bytes),
-            &input,
-            |b, i| b.iter(|| compress_lz4_fear(&i)),
-        );
+        // group.bench_with_input(
+        //     BenchmarkId::new("lz4_fear_rust", input_bytes),
+        //     &input,
+        //     |b, i| b.iter(|| compress_lz4_fear(&i)),
+        // );
 
-        group.bench_with_input(BenchmarkId::new("lz4_cpp", input_bytes), &input, |b, i| {
-            b.iter(|| lz4_cpp_block_compress(&i))
-        });
+        // group.bench_with_input(BenchmarkId::new("lz4_cpp", input_bytes), &input, |b, i| {
+        //     b.iter(|| lz4_cpp_block_compress(&i))
+        // });
 
-        group.bench_with_input(BenchmarkId::new("snap", input_bytes), &input, |b, i| {
-            b.iter(|| compress_snap(&i))
-        });
+        // group.bench_with_input(BenchmarkId::new("snap", input_bytes), &input, |b, i| {
+        //     b.iter(|| compress_snap(&i))
+        // });
     }
 
     group.finish();
@@ -199,32 +214,32 @@ fn bench_block_decompression_throughput(c: &mut Criterion) {
         //&comp_lz4,
         //|b, i| b.iter(|| lz4_flex::block::decompress_with_dict(&i, input.len(), &empty_vec)),
         //);
-        // group.bench_with_input(
-        //     BenchmarkId::new("lz4_flex_rust_master", input_bytes),
-        //     &comp_lz4,
-        //     |b, i| b.iter(|| lz4_flex_master::decompress(&i, input.len())),
-        // );
+        group.bench_with_input(
+            BenchmarkId::new("lz4_flex_rust_master", input_bytes),
+            &comp_lz4,
+            |b, i| b.iter(|| lz4_flex_master::decompress(&i, input.len())),
+        );
         // group.bench_with_input(
         //     BenchmarkId::new("lz4_redox_rust", input_bytes),
         //     &comp_lz4,
         //     |b, i| b.iter(|| lz4_compress::decompress(&i)),
         // );
-        group.bench_with_input(
-            BenchmarkId::new("lz4_fear_rust", input_bytes),
-            &comp_lz4,
-            |b, i| b.iter(|| decompress_lz4_fear(&i)),
-        );
+        // group.bench_with_input(
+        //     BenchmarkId::new("lz4_fear_rust", input_bytes),
+        //     &comp_lz4,
+        //     |b, i| b.iter(|| decompress_lz4_fear(&i)),
+        // );
 
-        group.bench_with_input(
-            BenchmarkId::new("lz4_cpp", input_bytes),
-            &comp_lz4,
-            |b, i| b.iter(|| lz4_cpp_block_decompress(&i, input.len())),
-        );
+        // group.bench_with_input(
+        //     BenchmarkId::new("lz4_cpp", input_bytes),
+        //     &comp_lz4,
+        //     |b, i| b.iter(|| lz4_cpp_block_decompress(&i, input.len())),
+        // );
 
-        let comp_snap = compress_snap(&input);
-        group.bench_with_input(BenchmarkId::new("snap", input_bytes), &comp_snap, |b, i| {
-            b.iter(|| decompress_snap(&i))
-        });
+        // let comp_snap = compress_snap(&input);
+        // group.bench_with_input(BenchmarkId::new("snap", input_bytes), &comp_snap, |b, i| {
+        //     b.iter(|| decompress_snap(&i))
+        // });
     }
 
     group.finish();
@@ -246,30 +261,40 @@ fn bench_frame_decompression_throughput(c: &mut Criterion) {
 
         group.bench_with_input(
             BenchmarkId::new("lz4_flex_rust_indep", input_bytes),
-            &comp_lz4_linked,
-            |b, i| b.iter(|| lz4_flex_frame_decompress(&i)),
-        );
-        group.bench_with_input(
-            BenchmarkId::new("lz4_flex_rust_linked", input_bytes),
-            &comp_lz4_linked,
-            |b, i| b.iter(|| lz4_flex_frame_decompress(&i)),
-        );
-
-        group.bench_with_input(
-            BenchmarkId::new("lz4_cpp_indep", input_bytes),
             &comp_lz4_indep,
-            |b, i| b.iter(|| lz4_cpp_frame_decompress(&i)),
+            |b, i| b.iter(|| lz4_flex_frame_decompress(&i)),
         );
+        // group.bench_with_input(
+        //     BenchmarkId::new("lz4_flex_rust_linked", input_bytes),
+        //     &comp_lz4_linked,
+        //     |b, i| b.iter(|| lz4_flex_frame_decompress(&i)),
+        // );
         group.bench_with_input(
-            BenchmarkId::new("lz4_cpp_linked", input_bytes),
-            &comp_lz4_linked,
-            |b, i| b.iter(|| lz4_cpp_frame_decompress(&i)),
+            BenchmarkId::new("lz4_flex_master_rust_indep", input_bytes),
+            &comp_lz4_indep,
+            |b, i| b.iter(|| lz4_flex_master_frame_decompress(&i)),
         );
+        // group.bench_with_input(
+        //     BenchmarkId::new("lz4_flex_master_rust_linked", input_bytes),
+        //     &comp_lz4_linked,
+        //     |b, i| b.iter(|| lz4_flex_master_frame_decompress(&i)),
+        // );
 
-        let comp_snap = compress_snap_frame(&input);
-        group.bench_with_input(BenchmarkId::new("snap", input_bytes), &comp_snap, |b, i| {
-            b.iter(|| decompress_snap_frame(&i))
-        });
+        // group.bench_with_input(
+        //     BenchmarkId::new("lz4_cpp_indep", input_bytes),
+        //     &comp_lz4_indep,
+        //     |b, i| b.iter(|| lz4_cpp_frame_decompress(&i)),
+        // );
+        // group.bench_with_input(
+        //     BenchmarkId::new("lz4_cpp_linked", input_bytes),
+        //     &comp_lz4_linked,
+        //     |b, i| b.iter(|| lz4_cpp_frame_decompress(&i)),
+        // );
+
+        // let comp_snap = compress_snap_frame(&input);
+        // group.bench_with_input(BenchmarkId::new("snap", input_bytes), &comp_snap, |b, i| {
+        //     b.iter(|| decompress_snap_frame(&i))
+        // });
     }
 
     group.finish();
@@ -297,32 +322,55 @@ fn bench_frame_compression_throughput(c: &mut Criterion) {
                 })
             },
         );
+        // group.bench_with_input(
+        //     BenchmarkId::new("lz4_flex_rust_linked", input_bytes),
+        //     &input,
+        //     |b, i| {
+        //         b.iter(|| {
+        //             let mut frame_info = lz4_flex::frame::FrameInfo::new();
+        //             frame_info.block_mode = lz4_flex::frame::BlockMode::Linked;
+        //             lz4_flex_frame_compress_with(frame_info, i)
+        //         })
+        //     },
+        // );
+
         group.bench_with_input(
-            BenchmarkId::new("lz4_flex_rust_linked", input_bytes),
+            BenchmarkId::new("lz4_flex_master_rust_indep", input_bytes),
             &input,
             |b, i| {
                 b.iter(|| {
-                    let mut frame_info = lz4_flex::frame::FrameInfo::new();
-                    frame_info.block_mode = lz4_flex::frame::BlockMode::Linked;
-                    lz4_flex_frame_compress_with(frame_info, i)
+                    let mut frame_info = lz4_flex_master::frame::FrameInfo::new();
+                    frame_info.block_mode = lz4_flex_master::frame::BlockMode::Independent;
+                    lz4_flex_master_frame_compress_with(frame_info, i)
                 })
             },
         );
+        // group.bench_with_input(
+        //     BenchmarkId::new("lz4_flex_master_rust_linked", input_bytes),
+        //     &input,
+        //     |b, i| {
+        //         b.iter(|| {
+        //             let mut frame_info = lz4_flex_master::frame::FrameInfo::new();
+        //             frame_info.block_mode = lz4_flex_master::frame::BlockMode::Linked;
+        //             lz4_flex_master_frame_compress_with(frame_info, i)
+        //         })
+        //     },
+        // );
 
-        group.bench_with_input(
-            BenchmarkId::new("lz4_cpp_indep", input_bytes),
-            &input,
-            |b, i| b.iter(|| lz4_cpp_frame_compress(i, true)),
-        );
-        group.bench_with_input(
-            BenchmarkId::new("lz4_cpp_linked", input_bytes),
-            &input,
-            |b, i| b.iter(|| lz4_cpp_frame_compress(i, false)),
-        );
+        // group.bench_with_input(
+        //     BenchmarkId::new("lz4_cpp_indep", input_bytes),
+        //     &input,
+        //     |b, i| b.iter(|| lz4_cpp_frame_compress(i, true)),
+        // );
+        // group.bench_with_input(
+        //     BenchmarkId::new("lz4_cpp_linked", input_bytes),
+        //     &input,
+        //     |b, i| b.iter(|| lz4_cpp_frame_compress(i, false)),
+        // );
 
-        group.bench_with_input(BenchmarkId::new("snap", input_bytes), &input, |b, i| {
-            b.iter(|| compress_snap_frame(i))
-        });
+        // group.bench_with_input(BenchmarkId::new("snap", input_bytes), &input, |b, i| {
+        //     b.iter(|| compress_snap_frame(i))
+        // });
     }
 
     group.finish();

--- a/src/block/compress.rs
+++ b/src/block/compress.rs
@@ -7,12 +7,13 @@
 use crate::block::hashtable::get_table_size;
 use crate::block::hashtable::HashTable;
 use crate::block::hashtable::{HashTableU16, HashTableU32, HashTableUsize};
-use crate::block::Sink;
 use crate::block::END_OFFSET;
 use crate::block::LZ4_MIN_LENGTH;
 use crate::block::MAX_DISTANCE;
 use crate::block::MFLIMIT;
 use crate::block::MINMATCH;
+use crate::sink::Sink;
+use crate::sink::VecSink;
 use alloc::vec::Vec;
 
 #[cfg(feature = "safe-encode")]
@@ -236,21 +237,18 @@ fn write_integer(output: &mut Sink, mut n: usize) {
         let bulk = n / (4 * 0xFF);
         n %= 4 * 0xFF;
         unsafe {
-            output
-                .output
-                .get_unchecked_mut(output.pos()..output.pos() + 4 * bulk)
-                .fill(0xFF)
+            core::ptr::write_bytes(output.pos_mut_ptr(), 0xFF, 4 * bulk);
+            output.set_pos(output.pos() + 4 * bulk);
         }
-        output.set_pos(output.pos() + 4 * bulk);
     }
 
     // Handle last 1 to 4 bytes
     push_u32(output, 0xFFFFFFFF);
     // Updating output len for the remainder
-    output.set_pos(output.pos() - 4 + 1 + n / 255);
     unsafe {
+        output.set_pos(output.pos() - 4 + 1 + n / 255);
         // Write the remaining byte.
-        *output.as_mut_ptr().sub(1) = (n % 255) as u8;
+        *output.pos_mut_ptr().sub(1) = (n % 255) as u8;
     }
 }
 
@@ -334,30 +332,26 @@ fn backtrack_match(
 /// A similar const argument could be used to disable the Prefix mode (eg. USE_PREFIX),
 /// which would impose `input_pos == 0 && input_stream_offset == 0`. Experiments didn't
 /// show significant improvement though.
-#[inline]
+#[inline(never)] // Avoid inlining as experiments shows it affects performance negatively.
 pub(crate) fn compress_internal<T: HashTable, const USE_DICT: bool>(
     input: &[u8],
     input_pos: usize,
-    output: &mut [u8],
-    output_pos: usize,
+    output: &mut Sink,
     dict: &mut T,
     ext_dict: &[u8],
     input_stream_offset: usize,
 ) -> Result<usize, CompressError> {
-    let mut output = Sink {
-        output,
-        pos: output_pos,
-    };
-    let output = &mut output;
     assert!(input_pos <= input.len());
-    assert!(ext_dict.len() <= super::WINDOW_SIZE);
-    assert!(ext_dict.len() <= input_stream_offset);
     if USE_DICT {
+        assert!(ext_dict.len() <= super::WINDOW_SIZE);
+        assert!(ext_dict.len() <= input_stream_offset);
         // Check for overflow hazard when using ext_dict
         assert!(input_stream_offset
             .checked_add(input.len())
             .and_then(|i| i.checked_add(ext_dict.len()))
             .map_or(false, |i| i <= isize::MAX as usize));
+    } else {
+        assert!(ext_dict.is_empty());
     }
     if output.capacity() - output.pos() < get_maximum_output_size(input.len() - input_pos) {
         return Err(CompressError::OutputTooSmall);
@@ -511,8 +505,8 @@ fn push_byte(output: &mut Sink, el: u8) {
 #[cfg(not(feature = "safe-encode"))]
 fn push_byte(output: &mut Sink, el: u8) {
     unsafe {
-        core::ptr::write(output.as_mut_ptr(), el);
-        output.pos += 1;
+        core::ptr::write(output.pos_mut_ptr(), el);
+        output.set_pos(output.pos() + 1);
     }
 }
 
@@ -526,46 +520,29 @@ fn push_u16(output: &mut Sink, el: u16) {
 #[cfg(not(feature = "safe-encode"))]
 fn push_u16(output: &mut Sink, el: u16) {
     unsafe {
-        output
-            .output
-            .get_unchecked_mut(output.pos()..output.pos() + 2)
-            .copy_from_slice(&el.to_le_bytes())
-    };
-    output.pos += 2;
-}
-
-#[inline]
-#[cfg(feature = "safe-encode")]
-fn push_u32(output: &mut Sink, el: u32) {
-    output.extend_from_slice(&el.to_le_bytes());
+        core::ptr::copy_nonoverlapping(el.to_le_bytes().as_ptr(), output.pos_mut_ptr(), 2);
+        output.set_pos(output.pos() + 2);
+    }
 }
 
 #[inline]
 #[cfg(not(feature = "safe-encode"))]
 fn push_u32(output: &mut Sink, el: u32) {
     unsafe {
-        output
-            .output
-            .get_unchecked_mut(output.pos()..output.pos() + 4)
-            .copy_from_slice(&el.to_le_bytes())
-    };
-    output.pos += 4;
+        core::ptr::copy_nonoverlapping(el.to_le_bytes().as_ptr(), output.pos_mut_ptr(), 4);
+        output.set_pos(output.pos() + 4);
+    }
 }
 
 #[inline(always)] // (always) necessary otherwise compiler fails to inline it
 #[cfg(feature = "safe-encode")]
 fn copy_literals_wild(output: &mut Sink, input: &[u8], input_start: usize, len: usize) {
     match len {
-        0..=8 => output.output[output.pos..output.pos + 8]
-            .copy_from_slice(&input[input_start..input_start + 8]),
-        9..=16 => output.output[output.pos..output.pos + 16]
-            .copy_from_slice(&input[input_start..input_start + 16]),
-        17..=24 => output.output[output.pos..output.pos + 24]
-            .copy_from_slice(&input[input_start..input_start + 24]),
-        _ => output.output[output.pos..output.pos + len]
-            .copy_from_slice(&input[input_start..input_start + len]),
+        0..=8 => output.extend_from_slice_wild(&input[input_start..input_start + 8], len),
+        9..=16 => output.extend_from_slice_wild(&input[input_start..input_start + 16], len),
+        17..=24 => output.extend_from_slice_wild(&input[input_start..input_start + 24], len),
+        _ => output.extend_from_slice_wild(&input[input_start..input_start + len], len),
     }
-    output.pos += len;
 }
 
 #[inline]
@@ -577,27 +554,67 @@ fn copy_literals_wild(output: &mut Sink, input: &[u8], input_start: usize, len: 
         // Note: This used to be a wild copy loop of 8 bytes, but the compiler consistently
         // transformed it into a call to memcopy, which hurts performance significantly for
         // small copies, which are common.
+        let start_ptr = input.as_ptr().add(input_start);
         match len {
-            0..=8 => output
-                .output
-                .get_unchecked_mut(output.pos..output.pos + 8)
-                .copy_from_slice(input.get_unchecked(input_start..input_start + 8)),
-            9..=16 => output
-                .output
-                .get_unchecked_mut(output.pos..output.pos + 16)
-                .copy_from_slice(input.get_unchecked(input_start..input_start + 16)),
-            17..=24 => output
-                .output
-                .get_unchecked_mut(output.pos..output.pos + 24)
-                .copy_from_slice(input.get_unchecked(input_start..input_start + 24)),
-            _ => core::ptr::copy_nonoverlapping(
-                input.as_ptr().add(input_start),
-                output.as_mut_ptr(),
-                len,
-            ),
+            0..=8 => core::ptr::copy_nonoverlapping(start_ptr, output.pos_mut_ptr(), 8),
+            9..=16 => core::ptr::copy_nonoverlapping(start_ptr, output.pos_mut_ptr(), 16),
+            17..=24 => core::ptr::copy_nonoverlapping(start_ptr, output.pos_mut_ptr(), 24),
+            _ => core::ptr::copy_nonoverlapping(start_ptr, output.pos_mut_ptr(), len),
         }
+        output.set_pos(output.pos() + len);
     }
-    output.pos += len;
+}
+
+#[inline]
+pub(crate) fn compress_into_sink(input: &[u8], output: &mut Sink) -> Result<usize, CompressError> {
+    let (dict_size, dict_bitshift) = get_table_size(input.len());
+    if input.len() < u16::MAX as usize {
+        let mut dict = HashTableU16::new(dict_size, dict_bitshift);
+        compress_internal::<_, false>(input, 0, output, &mut dict, b"", 0)
+    } else if input.len() < u32::MAX as usize {
+        let mut dict = HashTableU32::new(dict_size, dict_bitshift);
+        compress_internal::<_, false>(input, 0, output, &mut dict, b"", 0)
+    } else {
+        let mut dict = HashTableUsize::new(dict_size, dict_bitshift);
+        compress_internal::<_, false>(input, 0, output, &mut dict, b"", 0)
+    }
+}
+
+/// Same as compress_into_sink but with supports external dictionary
+#[inline]
+pub(crate) fn compress_into_sink_with_dict(
+    input: &[u8],
+    output: &mut Sink,
+    mut dict_data: &[u8],
+) -> Result<usize, CompressError> {
+    let (dict_size, dict_bitshift) = get_table_size(input.len());
+    if dict_data.len() + input.len() < u16::MAX as usize {
+        let mut dict = HashTableU16::new(dict_size, dict_bitshift);
+        init_dict(&mut dict, &mut dict_data);
+        compress_internal::<_, true>(input, 0, output, &mut dict, dict_data, dict_data.len())
+    } else if dict_data.len() + input.len() < u32::MAX as usize {
+        let mut dict = HashTableU32::new(dict_size, dict_bitshift);
+        init_dict(&mut dict, &mut dict_data);
+        compress_internal::<_, true>(input, 0, output, &mut dict, dict_data, dict_data.len())
+    } else {
+        let mut dict = HashTableUsize::new(dict_size, dict_bitshift);
+        init_dict(&mut dict, &mut dict_data);
+        compress_internal::<_, true>(input, 0, output, &mut dict, dict_data, dict_data.len())
+    }
+}
+
+#[inline]
+fn init_dict<T: HashTable>(dict: &mut T, dict_data: &mut &[u8]) {
+    if dict_data.len() > WINDOW_SIZE {
+        *dict_data = &dict_data[dict_data.len() - WINDOW_SIZE..];
+    }
+    let mut i = 0usize;
+    while i + core::mem::size_of::<usize>() <= dict_data.len() {
+        let hash = T::get_hash_at(dict_data, i);
+        dict.put_at(hash, i);
+        // Note: The 3 byte step was copied from the reference implementation, it could be arbitrary.
+        i += 3;
+    }
 }
 
 /// Returns the maximum output size of the compressed data.
@@ -618,17 +635,7 @@ pub fn compress_into(
     output: &mut [u8],
     output_pos: usize,
 ) -> Result<usize, CompressError> {
-    let (dict_size, dict_bitshift) = get_table_size(input.len());
-    if input.len() < u16::MAX as usize {
-        let mut dict = HashTableU16::new(dict_size, dict_bitshift);
-        compress_internal::<_, false>(input, 0, output, output_pos, &mut dict, b"", 0)
-    } else if input.len() < u32::MAX as usize {
-        let mut dict = HashTableU32::new(dict_size, dict_bitshift);
-        compress_internal::<_, false>(input, 0, output, output_pos, &mut dict, b"", 0)
-    } else {
-        let mut dict = HashTableUsize::new(dict_size, dict_bitshift);
-        compress_internal::<_, false>(input, 0, output, output_pos, &mut dict, b"", 0)
-    }
+    compress_into_sink(input, &mut Sink::new(output, output_pos))
 }
 
 /// Compress all bytes of `input` into `output`.
@@ -641,106 +648,38 @@ pub fn compress_into_with_dict(
     input: &[u8],
     output: &mut [u8],
     output_pos: usize,
-    mut dict_data: &[u8],
+    dict_data: &[u8],
 ) -> Result<usize, CompressError> {
-    let (dict_size, dict_bitshift) = get_table_size(input.len());
-    if dict_data.len() + input.len() < u16::MAX as usize {
-        let mut dict = HashTableU16::new(dict_size, dict_bitshift);
-        init_dict(&mut dict, &mut dict_data);
-        compress_internal::<_, true>(
-            input,
-            0,
-            output,
-            output_pos,
-            &mut dict,
-            dict_data,
-            dict_data.len(),
-        )
-    } else if dict_data.len() + input.len() < u32::MAX as usize {
-        let mut dict = HashTableU32::new(dict_size, dict_bitshift);
-        init_dict(&mut dict, &mut dict_data);
-        compress_internal::<_, true>(
-            input,
-            0,
-            output,
-            output_pos,
-            &mut dict,
-            dict_data,
-            dict_data.len(),
-        )
-    } else {
-        let mut dict = HashTableUsize::new(dict_size, dict_bitshift);
-        init_dict(&mut dict, &mut dict_data);
-        compress_internal::<_, true>(
-            input,
-            0,
-            output,
-            output_pos,
-            &mut dict,
-            dict_data,
-            dict_data.len(),
-        )
-    }
-}
-
-#[inline]
-fn init_dict<T: HashTable>(dict: &mut T, dict_data: &mut &[u8]) {
-    if dict_data.len() > WINDOW_SIZE {
-        *dict_data = &dict_data[dict_data.len() - WINDOW_SIZE..];
-    }
-    let mut i = 0usize;
-    while i + core::mem::size_of::<usize>() <= dict_data.len() {
-        let hash = T::get_hash_at(dict_data, i);
-        dict.put_at(hash, i);
-        // Note: The 3 byte step was copied from the reference implementation, it could be arbitrary.
-        i += 3;
-    }
-}
-
-#[inline]
-pub(crate) fn get_output_vec(input_len: usize) -> Vec<u8> {
-    let max_size = get_maximum_output_size(input_len);
-
-    let mut compressed = Vec::with_capacity(max_size);
-    #[cfg(not(feature = "safe-encode"))]
-    {
-        unsafe { compressed.set_len(max_size) };
-    }
-    #[cfg(feature = "safe-encode")]
-    {
-        compressed.resize(max_size, 0);
-    }
-    compressed
+    compress_into_sink_with_dict(input, &mut Sink::new(output, output_pos), dict_data)
 }
 
 /// Compress all bytes of `input` into `output`. The uncompressed size will be prepended as a little endian u32.
 /// Can be used in conjunction with `decompress_size_prepended`
 #[inline]
 pub fn compress_prepend_size(input: &[u8]) -> Vec<u8> {
-    let mut compressed = get_output_vec(4 + input.len());
-    let mut sink: Sink = (&mut compressed).into();
-    push_u32(&mut sink, input.len() as u32);
-    let compressed_len = compress_into(input, &mut sink.output, sink.pos).unwrap();
-    compressed.truncate(4 + compressed_len);
+    let max_output_size = get_maximum_output_size(input.len());
+    let mut compressed = Vec::with_capacity(4 + max_output_size);
+    compressed.extend_from_slice(&(input.len() as u32).to_le_bytes());
+    compress_into_sink(input, &mut VecSink::new(&mut compressed, 4, 0)).unwrap();
     compressed
 }
 
 /// Compress all bytes of `input`.
 #[inline]
 pub fn compress(input: &[u8]) -> Vec<u8> {
-    let mut compressed = get_output_vec(input.len());
-    let mut sink: Sink = (&mut compressed).into();
-    let compressed_len = compress_into(input, &mut sink.output, sink.pos).unwrap();
-    compressed.truncate(compressed_len);
+    let max_output_size = get_maximum_output_size(input.len());
+    let mut compressed = Vec::with_capacity(max_output_size);
+    compress_into_sink(input, &mut VecSink::new(&mut compressed, 0, 0)).unwrap();
     compressed
 }
 
 /// Compress all bytes of `input` with an external dictionary.
 #[inline]
 pub fn compress_with_dict(input: &[u8], ext_dict: &[u8]) -> Vec<u8> {
-    let mut compressed = get_output_vec(input.len());
-    let compressed_len = compress_into_with_dict(input, &mut compressed, 0, ext_dict).unwrap();
-    compressed.truncate(compressed_len);
+    let max_output_size = get_maximum_output_size(input.len());
+    let mut compressed = Vec::with_capacity(max_output_size);
+    compress_into_sink_with_dict(input, &mut VecSink::new(&mut compressed, 0, 0), ext_dict)
+        .unwrap();
     compressed
 }
 
@@ -748,13 +687,11 @@ pub fn compress_with_dict(input: &[u8], ext_dict: &[u8]) -> Vec<u8> {
 /// Can be used in conjunction with `decompress_size_prepended_with_dict`
 #[inline]
 pub fn compress_prepend_size_with_dict(input: &[u8], ext_dict: &[u8]) -> Vec<u8> {
-    // In most cases, the compression won't expand the size, so we set the input size as capacity.
-    let mut compressed = get_output_vec(4 + input.len());
-    let mut sink: Sink = (&mut compressed).into();
-    push_u32(&mut sink, input.len() as u32);
-    let compressed_len =
-        compress_into_with_dict(input, &mut sink.output, sink.pos, ext_dict).unwrap();
-    compressed.truncate(4 + compressed_len);
+    let max_output_size = get_maximum_output_size(input.len());
+    let mut compressed = Vec::with_capacity(4 + max_output_size);
+    compressed.extend_from_slice(&(input.len() as u32).to_le_bytes());
+    compress_into_sink_with_dict(input, &mut VecSink::new(&mut compressed, 4, 0), ext_dict)
+        .unwrap();
     compressed
 }
 
@@ -917,14 +854,15 @@ mod tests {
         let dict_cutoff = dict.len() / 2;
         let output_start = dict.len() - dict_cutoff;
         uncompressed[..output_start].copy_from_slice(&dict[dict_cutoff..]);
-
-        let uncomp_len = crate::block::decompress::decompress_into_with_dict(
-            &compressed,
-            &mut uncompressed,
-            output_start,
-            &dict[..dict_cutoff],
-        )
-        .unwrap();
+        let uncomp_len = {
+            let mut sink = Sink::new(&mut uncompressed[..], output_start);
+            crate::block::decompress::decompress_internal::<true>(
+                &compressed,
+                &mut sink,
+                &dict[..dict_cutoff],
+            )
+            .unwrap()
+        };
         assert_eq!(input.len(), uncomp_len);
         assert_eq!(
             input,

--- a/src/block/decompress.rs
+++ b/src/block/decompress.rs
@@ -197,7 +197,7 @@ pub fn decompress_into_with_dict(
 /// Decompress all bytes of `input` into `output`.
 ///
 /// Returns the number of bytes written (decompressed) into `output`.
-#[inline]
+#[inline(always)] // (always) necessary to get the best performance in non LTO builds
 pub(crate) fn decompress_internal<const USE_DICT: bool>(
     input: &[u8],
     output: &mut Sink,

--- a/src/block/decompress_safe.rs
+++ b/src/block/decompress_safe.rs
@@ -105,7 +105,7 @@ pub fn decompress_into_with_dict(
 /// Decompress all bytes of `input` into `output`.
 ///
 /// Returns the number of bytes written (decompressed) into `output`.
-#[inline(always)]
+#[inline(always)] // (always) necessary to get the best performance in non LTO builds
 pub(crate) fn decompress_internal<const USE_DICT: bool>(
     input: &[u8],
     output: &mut Sink,

--- a/src/frame/decompress.rs
+++ b/src/frame/decompress.rs
@@ -8,7 +8,10 @@ use twox_hash::XxHash32;
 
 use super::header::{BlockInfo, BlockMode, FrameInfo, MAX_FRAME_INFO_SIZE, MIN_FRAME_INFO_SIZE};
 use super::Error;
-use crate::block::WINDOW_SIZE;
+use crate::{
+    block::WINDOW_SIZE,
+    sink::{Sink, VecSink},
+};
 
 /// A reader for decompressing the LZ4 frame format
 ///
@@ -25,7 +28,7 @@ use crate::block::WINDOW_SIZE;
 /// let json: serde_json::Value = serde_json::from_reader(decompressed_input).unwrap();
 /// ```
 ///
-/// # Example
+/// # Example 2
 /// Deserializing multiple json values out of a compressed file
 ///
 /// ```no_run
@@ -214,6 +217,8 @@ impl<R: io::Read> FrameDecoder<R> {
                 if len > max_block_size {
                     return Err(Error::BlockTooBig.into());
                 }
+                // TODO: Attempt to avoid initialization when Read::read_buf is stabilized
+                // https://github.com/rust-lang/rust/issues/78485
                 self.r.read_exact(vec_resize_and_get_mut(
                     &mut self.dst,
                     self.dst_start,
@@ -235,16 +240,13 @@ impl<R: io::Read> FrameDecoder<R> {
                 if len > max_block_size {
                     return Err(Error::BlockTooBig.into());
                 }
+                // TODO: Attempt to avoid initialization when Read::read_buf is stabilized
+                // https://github.com/rust-lang/rust/issues/78485
                 self.r
                     .read_exact(vec_resize_and_get_mut(&mut self.src, 0, len))?;
                 if frame_info.block_checksums {
                     let expected_checksum = Self::read_checksum(&mut self.r)?;
                     Self::check_block_checksum(&self.src[..len], expected_checksum)?;
-                }
-
-                // Ensure dst has enough len to decompress into
-                if self.dst.len() - self.dst_start < max_block_size {
-                    vec_set_len(&mut self.dst, self.dst_start + max_block_size);
                 }
 
                 let with_dict_mode =
@@ -255,19 +257,19 @@ impl<R: io::Read> FrameDecoder<R> {
                     let ext_dict = &tail[..self.ext_dict_len];
 
                     debug_assert!(head.len() - self.dst_start >= max_block_size);
-                    crate::block::decompress::decompress_into_with_dict(
+                    crate::block::decompress::decompress_internal::<true>(
                         &self.src[..len],
-                        head,
-                        self.dst_start,
+                        &mut Sink::new(head, self.dst_start),
                         ext_dict,
                     )
                 } else {
                     // Independent blocks OR linked blocks with only prefix data
-                    debug_assert!(self.dst.len() - self.dst_start >= max_block_size);
-                    crate::block::decompress::decompress_into(
+                    debug_assert!(self.dst.capacity() - self.dst_start >= max_block_size);
+
+                    crate::block::decompress::decompress_internal::<false>(
                         &self.src[..len],
-                        &mut self.dst,
-                        self.dst_start,
+                        &mut VecSink::new(&mut self.dst, 0, self.dst_start),
+                        b"",
                     )
                 }
                 .map_err(Error::DecompressionError)?;
@@ -404,31 +406,12 @@ impl<R: fmt::Debug + io::Read> fmt::Debug for FrameDecoder<R> {
     }
 }
 
-/// Similar to set_len but panics if the vec doesn't have enough capacity.
-#[cfg(feature = "safe-decode")]
-#[inline]
-fn vec_set_len(v: &mut Vec<u8>, new_len: usize) {
-    // The assert isn't strictly needed but we want to assert the same behavior as the unsafe version
-    assert!(new_len <= v.capacity());
-    v.resize(new_len, 0);
-}
-
-/// Similar to set_len but panics if the vec doesn't have enough capacity.
-#[cfg(not(feature = "safe-decode"))]
-#[inline]
-fn vec_set_len(v: &mut Vec<u8>, new_len: usize) {
-    assert!(new_len <= v.capacity());
-    unsafe {
-        v.set_len(new_len);
-    }
-}
-
 /// Similar to `v.get_mut(start..end) but will adjust the len if needed.
 /// Panics if there's not enough capacity.
 #[inline]
 fn vec_resize_and_get_mut(v: &mut Vec<u8>, start: usize, end: usize) -> &mut [u8] {
     if end > v.len() {
-        vec_set_len(v, end);
+        v.resize(end, 0)
     }
     &mut v[start..end]
 }

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -4,7 +4,9 @@
 
 use std::{fmt, io};
 
+#[cfg_attr(feature = "safe-encode", forbid(unsafe_code))]
 pub(crate) mod compress;
+#[cfg_attr(feature = "safe-decode", forbid(unsafe_code))]
 pub(crate) mod decompress;
 pub(crate) mod header;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,3 +89,5 @@ pub mod frame;
 pub use block::{compress, compress_into, compress_prepend_size};
 
 pub use block::{decompress, decompress_into, decompress_size_prepended};
+
+pub(crate) mod sink;

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,0 +1,277 @@
+use core::mem::MaybeUninit;
+use core::ops::{Deref, DerefMut};
+use alloc::vec::Vec;
+
+/// Sink is used as target to de/compress data into a preallocated and possibly uninitialized memory space.
+/// Sink can be created from a `Vec` or a `Slice`. The new pos on the data after the operation
+/// can be retrieved via `sink.pos()`.
+///
+/// # Handling of Capacity
+/// Extend methods will panic if there's insufficient capacity left in the Sink.
+///
+/// # Safety invariants
+///   - `self.output[.. self.pos]` is always initialized.
+pub struct Sink<'a> {
+    /// The working slice, which may contain uninitialized bytes
+    output: &'a mut [MaybeUninit<u8>],
+    /// The Sink write position.
+    /// Also the number of bytes from the start of `output` guaranteed to be initialized.
+    pos: usize,
+}
+
+impl<'a> Sink<'a> {
+    /// Creates a `Sink` backed by the given byte slice.
+    #[inline]
+    pub fn new(output: &'a mut [u8], pos: usize) -> Self {
+        // SAFETY: Caller guarantees that all elements of `output` are initialized.
+        let _ = &mut output[..pos]; // bounds check pos
+        Sink {
+            output: slice_as_uninit_mut(output),
+            pos,
+        }
+    }
+}
+
+impl<'a> Sink<'a> {
+    /// Pushes a byte to the end of the Sink.
+    #[cfg(any(feature = "safe-encode", feature = "safe-decode"))]
+    #[inline]
+    pub fn push(&mut self, byte: u8) {
+        self.output[self.pos] = MaybeUninit::new(byte);
+        self.pos += 1;
+    }
+
+    /// Pushes `len` elements of `byte` to the end of the Sink.
+    /// # Panics
+    /// Panics if `copy_len` > `data.len()`.
+    #[cfg(any(feature = "safe-encode", feature = "safe-decode"))]
+    #[inline]
+    pub fn extend_with_fill(&mut self, byte: u8, len: usize) {
+        self.output[self.pos..self.pos + len].fill(MaybeUninit::new(byte));
+        self.pos += len;
+    }
+
+    /// Extends the Sink with `data` but only advances the sink by `copy_len`.
+    /// # Panics
+    /// Panics if `copy_len` > `data.len()`.
+    #[inline]
+    pub fn extend_from_slice_wild(&mut self, data: &[u8], copy_len: usize) {
+        // SAFETY: The assertion prevent Sink from exposing uninitialized data.
+        assert!(copy_len <= data.len());
+        self.output[self.pos..self.pos + data.len()].copy_from_slice(slice_as_uninit_ref(data));
+        self.pos += copy_len;
+    }
+
+    /// Extends the Sink with `data`.
+    #[inline]
+    pub fn extend_from_slice(&mut self, data: &[u8]) {
+        self.extend_from_slice_wild(data, data.len())
+    }
+
+    /// Copies `wild_len` bytes starting from `start` to the end of the Sink.
+    /// The position of the Sink is increased by `copy_len` NOT `wild_len`;
+    /// # Panics
+    /// Panics if `start + copy_len` > `pos`.
+    /// Panics if `copy_len` > `wild_len`.
+    #[cfg(any(feature = "safe-encode", feature = "safe-decode"))]
+    #[inline]
+    pub fn extend_from_within_wild(&mut self, start: usize, wild_len: usize, copy_len: usize) {
+        // SAFETY: The assertions prevent Sink from exposing uninitialized data.
+        assert!(copy_len <= wild_len);
+        assert!(start + copy_len <= self.pos);
+        self.output.copy_within(start..start + wild_len, self.pos);
+        self.pos += copy_len;
+    }
+
+    /// Copies `len` bytes starting from `start` to the end of the Sink.
+    /// # Panics
+    /// Panics if `start` >= `pos`.
+    #[cfg(any(feature = "safe-encode", feature = "safe-decode"))]
+    #[inline]
+    pub fn extend_from_within(&mut self, start: usize, len: usize) {
+        self.extend_from_within_wild(start, len, len)
+    }
+
+    /// Copies `len` bytes starting from `start` to the end of the Sink.
+    /// Contrary to `extend_from_within`, the copy destination can overlap with
+    /// (self-reference) the copy source bytes.
+    /// In addition, a copy with `start` == `pos` is valid and will
+    /// fill the sink `len` zero bytes.
+    /// # Panics
+    /// Panics if `start` > `pos`.
+    #[cfg(any(feature = "safe-encode", feature = "safe-decode"))]
+    #[inline]
+    pub fn extend_from_within_overlapping(&mut self, start: usize, len: usize) {
+        // SAFETY: Sink safety invariant guarantees that the first `pos` items are initialized.
+        // But also accept start == pos as described in the function documentation.
+        assert!(start <= self.pos);
+        let offset = self.pos - start;
+        let out = &mut self.output[start..self.pos + len];
+        // Ensures that a copy w/ start == pos becomes a zero fill.
+        // This is the same behavior as the reference implementation.
+        out[offset] = MaybeUninit::new(0);
+        for i in offset..out.len() {
+            out[i] = out[i - offset];
+        }
+        self.pos += len;
+    }
+
+    /// Returns a raw ptr to the first byte of the Sink. Analogous to `[0..].as_ptr()`.
+    /// Note that the data under the pointer might be uninitialized.
+    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+    #[inline]
+    pub unsafe fn base_mut_ptr(&mut self) -> *mut u8 {
+        // SAFETY: `MaybeUninit<T>` is guaranteed to have the same layout as `T`
+        self.output.as_mut_ptr() as *mut u8
+    }
+
+    /// Returns a raw ptr to the first unfilled byte of the Sink. Analogous to `[pos..].as_ptr()`.
+    /// Note that the data under the pointer might be uninitialized.
+    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+    #[inline]
+    pub unsafe fn pos_mut_ptr(&mut self) -> *mut u8 {
+        // SAFETY: `MaybeUninit<T>` is guaranteed to have the same layout as `T`
+        self.output.as_mut_ptr().add(self.pos) as *mut u8
+    }
+
+    /// The current position (aka. len) of the the Sink.
+    #[inline]
+    pub fn pos(&self) -> usize {
+        self.pos
+    }
+
+    /// The total capacity of the Sink.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.output.len()
+    }
+
+    /// Forces the length of the vector to `new_pos`.
+    /// The caller is responsible for ensuring all bytes up to `new_pos` are properly initialized.
+    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+    #[inline]
+    pub unsafe fn set_pos(&mut self, new_pos: usize) {
+        debug_assert!(new_pos <= self.capacity());
+        self.pos = new_pos;
+    }
+
+    /// Returns the initialized section of the Sink. Analogous to `&[..pos]`.
+    #[cfg(any(test, feature = "safe-decode"))]
+    #[inline]
+    pub fn filled_slice(&self) -> &[u8] {
+        // SAFETY: from the safety invariant.
+        unsafe { core::slice::from_raw_parts_mut(self.output.as_ptr() as *mut u8, self.pos) }
+    }
+}
+
+/// A Sink wrapper backed by a Vec<u8>.
+pub struct VecSink<'a> {
+    sink: Sink<'a>,
+    offset: usize,
+    vec_ptr: *mut Vec<u8>,
+}
+
+impl<'a> VecSink<'a> {
+    /// Creates a `Sink` backed by the Vec bytes at `vec[offset..vec.capacity()]`.
+    /// Note that the bytes at `vec[output.len()..]` are actually uninitialized and will
+    /// not be readable until written.
+    /// When the `Sink` is dropped the Vec len will be adjusted to `offset` + `Sink.pos`.
+    #[inline]
+    pub fn new(output: &'a mut Vec<u8>, offset: usize, pos: usize) -> Self {
+        // SAFETY: Only the first `output.len` in `output` are initialized.
+        // Assert that the range output[offset + pos] is all initialized data.
+        let _ = &output[..offset + pos];
+
+        // SAFETY: Derive the pointer first, for stacked borrows reasons.
+        let vec_ptr = output as *mut Vec<u8>;
+
+        // SAFETY: `Vec` guarantees that `capacity` elements are available from `as_mut_ptr`.
+        // Only the first `output.len` elements are actually initialized but we use a slice of `MaybeUninit` for the entire range.
+        // `MaybeUninit<T>` is guaranteed to have the same layout as `T`.
+        let vec_with_spare = unsafe {
+            core::slice::from_raw_parts_mut(
+                output.as_mut_ptr() as *mut MaybeUninit<u8>,
+                output.capacity(),
+            )
+        };
+        VecSink {
+            sink: Sink {
+                output: &mut vec_with_spare[offset..],
+                pos,
+            },
+            offset,
+            vec_ptr,
+        }
+    }
+}
+
+impl<'a> Deref for VecSink<'a> {
+    type Target = Sink<'a>;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.sink
+    }
+}
+
+impl<'a> DerefMut for VecSink<'a> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.sink
+    }
+}
+
+impl<'a> Drop for VecSink<'a> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe { (&mut *self.vec_ptr).set_len(self.offset + self.sink.pos) }
+    }
+}
+
+#[inline]
+fn slice_as_uninit_ref(slice: &[u8]) -> &[MaybeUninit<u8>] {
+    // SAFETY: `&[T]` is guaranteed to have the same layout as `&[MaybeUninit<T>]`
+    unsafe { core::slice::from_raw_parts(slice.as_ptr() as *mut MaybeUninit<u8>, slice.len()) }
+}
+
+#[inline]
+fn slice_as_uninit_mut(slice: &mut [u8]) -> &mut [MaybeUninit<u8>] {
+    // SAFETY: `&mut [T]` is guaranteed to have the same layout as `&mut [MaybeUninit<T>]`
+    unsafe {
+        core::slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut MaybeUninit<u8>, slice.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sink_slice() {
+        let mut data = Vec::new();
+        data.resize(5, 0);
+        let mut sink = Sink::new(&mut data, 1);
+        assert_eq!(sink.pos(), 1);
+        assert_eq!(sink.capacity(), 5);
+        assert_eq!(sink.filled_slice(), &[0]);
+        sink.extend_from_slice(&[1, 2, 3]);
+        assert_eq!(sink.pos(), 4);
+        assert_eq!(sink.filled_slice(), &[0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_sink_vec() {
+        let mut data = Vec::with_capacity(5);
+        data.push(255); // not visible to the sink
+        data.push(0);
+        {
+            let mut sink = VecSink::new(&mut data, 1, 1);
+            assert_eq!(sink.pos(), 1);
+            assert_eq!(sink.capacity(), 4);
+            assert_eq!(sink.filled_slice(), &[0]);
+            sink.extend_from_slice(&[1, 2, 3]);
+            assert_eq!(sink.pos(), 4);
+            assert_eq!(sink.filled_slice(), &[0, 1, 2, 3]);
+        }
+        assert_eq!(data.as_slice(), &[255, 0, 1, 2, 3]);
+    }
+}

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,6 +1,6 @@
+use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 use core::ops::{Deref, DerefMut};
-use alloc::vec::Vec;
 
 /// Sink is used as target to de/compress data into a preallocated and possibly uninitialized memory space.
 /// Sink can be created from a `Vec` or a `Slice`. The new pos on the data after the operation


### PR DESCRIPTION
In order to safe guard against UB (Undefined Behavior) and safety issues
(exposing uninitialized data) the Sink abstraction is expanded to handle
uninitialized data safely.

Other alternatives were explored (eg. Sink trait) and the alternative in
this PR did show just as good performance but with less code churn and
compile time impact.

Sink changes
* Move Sink abstraction and related bits to its own module.
* Sink safety invariant is that it never exposes uninitialized data.
* Add additional methods to Sink (eg. extend_from_within) that can
safely operate over possibly uninitialized byte slices internally.

New VecSink
* Add VecSink wrapper which can be used to create Sinks over possibly
uninitialized Vec data.
* On drop VecSink will adjust the backing Vec length to cover the then
initialized bytes.

Unsafe Compression changes
* `write_u*` functions now use `core::ptr::write` so they can safely
operate on uninitialized data.

Safe compression changes
* Safe wild copies now use `Sink::extend_from_slice_wild` so they can
safely operate on uninitialized bytes.

Safe Decompression changes
* The previous 16 byte wild copy in the slow path didn't play well with
the new Sink as it could expose uninitialized bytes temporarily (which
now panics). It was replaced with fast-paths + fallback which performs
equally or better (eg. 66KB Json dataset).

Unsafe FrameDecoder changes
* Similar to the safe FrameDecoder, decoding a block is now required to
initialize the byte buffer passed to the underlying `Read::read` method.
This will be improved when `Read::read_buf` is stabilized.

Fixes #19