### PR TITLE
Expand Sink abstraction to handle/hide uninitialized data

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Run tests no-default-features (no safe-decode)
       run: cargo test --verbose --no-default-features --features frame
     - name: Run fuzz tests (safe)
-      run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test -- -max_total_time=10 || exit 1; done
+      run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test -- -max_total_time=30 || exit 1; done
     - name: Run fuzz tests (unsafe)
-      run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test --no-default-features -- -max_total_time=10 || exit 1; done
+      run: for fuzz_test in `cargo fuzz list`; do cargo fuzz run $fuzz_test --no-default-features -- -max_total_time=30 || exit 1; done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,15 @@ serde_json = "1.0"
 git = "https://github.com/main--/rust-lz-fear"
 
 # Uncomment to make lz4_flex master available as lz4_flex_master
-# [dev-dependencies.lz4_flex_master]
-#rev= "eb8c2e090485dcb5ef9e0da96bf72a95023753c1" # before this PR was merged
-# git = "https://github.com/PSeitz/lz4_flex"
-# package = "lz4_flex"
-#default-features=false
+[dev-dependencies.lz4_flex_master]
+git = "https://github.com/PSeitz/lz4_flex"
+package = "lz4_flex"
+# default-features=false
+# features = ["std", "frame"]
 
 [features]
 default = ["std", "safe-encode", "safe-decode", "frame"]
+# default = ["std", "frame"]
 safe-decode = []
 safe-encode = []
 checked-decode = []
@@ -48,7 +49,7 @@ twox-hash = { version = "1", default-features = false }
 [profile.bench]
 codegen-units = 1
 # debug = true
-lto = true
+# lto = true
 opt-level = 3
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,15 @@ serde_json = "1.0"
 git = "https://github.com/main--/rust-lz-fear"
 
 # Uncomment to make lz4_flex master available as lz4_flex_master
-[dev-dependencies.lz4_flex_master]
-git = "https://github.com/PSeitz/lz4_flex"
-package = "lz4_flex"
+# [dev-dependencies.lz4_flex_master]
+# rev= "eb8c2e090485dcb5ef9e0da96bf72a95023753c1" # before this PR was merged
+# git = "https://github.com/PSeitz/lz4_flex"
+# package = "lz4_flex"
 # default-features=false
-# features = ["std", "frame"]
+# features = ["std", "safe-encode", "safe-decode", "frame"]
 
 [features]
 default = ["std", "safe-encode", "safe-decode", "frame"]
-# default = ["std", "frame"]
 safe-decode = []
 safe-encode = []
 checked-decode = []
@@ -49,7 +49,7 @@ twox-hash = { version = "1", default-features = false }
 [profile.bench]
 codegen-units = 1
 # debug = true
-# lto = true
+lto = true
 opt-level = 3
 
 [profile.release]

--- a/benches/crit_bench.rs
+++ b/benches/crit_bench.rs
@@ -19,7 +19,7 @@ const COMPRESSION95K_VERY_GOOD_LOGO: &'static [u8] = include_bytes!("../logo.jpg
 const ALL: &[&[u8]] = &[
     COMPRESSION1K as &[u8],
     COMPRESSION34K as &[u8],
-    // COMPRESSION65K as &[u8],
+    COMPRESSION65K as &[u8],
     COMPRESSION66K as &[u8],
     // COMPRESSION10MB as &[u8],
     // COMPRESSION95K_VERY_GOOD_LOGO as &[u8],
@@ -117,24 +117,24 @@ pub fn lz4_flex_frame_decompress(input: &[u8]) -> Result<Vec<u8>, lz4_flex::fram
     Ok(out)
 }
 
-pub fn lz4_flex_master_frame_compress_with(
-    frame_info: lz4_flex_master::frame::FrameInfo,
-    input: &[u8],
-) -> Result<Vec<u8>, lz4_flex_master::frame::Error> {
-    let buffer = Vec::new();
-    let mut enc = lz4_flex_master::frame::FrameEncoder::with_frame_info(frame_info, buffer);
-    enc.write_all(input)?;
-    Ok(enc.finish()?)
-}
+// pub fn lz4_flex_master_frame_compress_with(
+//     frame_info: lz4_flex_master::frame::FrameInfo,
+//     input: &[u8],
+// ) -> Result<Vec<u8>, lz4_flex_master::frame::Error> {
+//     let buffer = Vec::new();
+//     let mut enc = lz4_flex_master::frame::FrameEncoder::with_frame_info(frame_info, buffer);
+//     enc.write_all(input)?;
+//     Ok(enc.finish()?)
+// }
 
-pub fn lz4_flex_master_frame_decompress(
-    input: &[u8],
-) -> Result<Vec<u8>, lz4_flex_master::frame::Error> {
-    let mut de = lz4_flex_master::frame::FrameDecoder::new(input);
-    let mut out = Vec::new();
-    de.read_to_end(&mut out)?;
-    Ok(out)
-}
+// pub fn lz4_flex_master_frame_decompress(
+//     input: &[u8],
+// ) -> Result<Vec<u8>, lz4_flex_master::frame::Error> {
+//     let mut de = lz4_flex_master::frame::FrameDecoder::new(input);
+//     let mut out = Vec::new();
+//     de.read_to_end(&mut out)?;
+//     Ok(out)
+// }
 
 fn bench_block_compression_throughput(c: &mut Criterion) {
     let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Linear);
@@ -152,39 +152,39 @@ fn bench_block_compression_throughput(c: &mut Criterion) {
             |b, i| b.iter(|| lz4_flex::compress(&i)),
         );
         // an empty slice that the compiler can't infer the size
-        //let empty_vec = std::env::args()
-        //.skip(1000000)
-        //.next()
-        //.unwrap_or_default()
-        //.into_bytes();
-        //group.bench_with_input(
-        //BenchmarkId::new("lz4_flex_rust_with_dict", input_bytes),
-        //&input,
-        //|b, i| b.iter(|| lz4_flex::block::compress_with_dict(&i, &empty_vec)),
-        //);
+        let empty_vec = std::env::args()
+            .skip(1000000)
+            .next()
+            .unwrap_or_default()
+            .into_bytes();
         group.bench_with_input(
-            BenchmarkId::new("lz4_flex_rust_master", input_bytes),
+            BenchmarkId::new("lz4_flex_rust_with_dict", input_bytes),
             &input,
-            |b, i| b.iter(|| lz4_flex_master::compress(&i)),
+            |b, i| b.iter(|| lz4_flex::block::compress_with_dict(&i, &empty_vec)),
         );
         // group.bench_with_input(
-        //     BenchmarkId::new("lz4_redox_rust", input_bytes),
+        //     BenchmarkId::new("lz4_flex_rust_master", input_bytes),
         //     &input,
-        //     |b, i| b.iter(|| lz4_compress::compress(&i)),
+        //     |b, i| b.iter(|| lz4_flex_master::compress(&i)),
         // );
-        // group.bench_with_input(
-        //     BenchmarkId::new("lz4_fear_rust", input_bytes),
-        //     &input,
-        //     |b, i| b.iter(|| compress_lz4_fear(&i)),
-        // );
+        group.bench_with_input(
+            BenchmarkId::new("lz4_redox_rust", input_bytes),
+            &input,
+            |b, i| b.iter(|| lz4_compress::compress(&i)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("lz4_fear_rust", input_bytes),
+            &input,
+            |b, i| b.iter(|| compress_lz4_fear(&i)),
+        );
 
-        // group.bench_with_input(BenchmarkId::new("lz4_cpp", input_bytes), &input, |b, i| {
-        //     b.iter(|| lz4_cpp_block_compress(&i))
-        // });
+        group.bench_with_input(BenchmarkId::new("lz4_cpp", input_bytes), &input, |b, i| {
+            b.iter(|| lz4_cpp_block_compress(&i))
+        });
 
-        // group.bench_with_input(BenchmarkId::new("snap", input_bytes), &input, |b, i| {
-        //     b.iter(|| compress_snap(&i))
-        // });
+        group.bench_with_input(BenchmarkId::new("snap", input_bytes), &input, |b, i| {
+            b.iter(|| compress_snap(&i))
+        });
     }
 
     group.finish();
@@ -208,42 +208,42 @@ fn bench_block_decompression_throughput(c: &mut Criterion) {
             |b, i| b.iter(|| lz4_flex::decompress(&i, input.len())),
         );
         // an empty slice that the compiler can't infer the size
-        //let empty_vec = std::env::args()
-        //.skip(1000000)
-        //.next()
-        //.unwrap_or_default()
-        //.into_bytes();
-        //group.bench_with_input(
-        //BenchmarkId::new("lz4_flex_rust_with_dict", input_bytes),
-        //&comp_lz4,
-        //|b, i| b.iter(|| lz4_flex::block::decompress_with_dict(&i, input.len(), &empty_vec)),
-        //);
+        let empty_vec = std::env::args()
+            .skip(1000000)
+            .next()
+            .unwrap_or_default()
+            .into_bytes();
         group.bench_with_input(
-            BenchmarkId::new("lz4_flex_rust_master", input_bytes),
+            BenchmarkId::new("lz4_flex_rust_with_dict", input_bytes),
             &comp_lz4,
-            |b, i| b.iter(|| lz4_flex_master::decompress(&i, input.len())),
+            |b, i| b.iter(|| lz4_flex::block::decompress_with_dict(&i, input.len(), &empty_vec)),
         );
         // group.bench_with_input(
-        //     BenchmarkId::new("lz4_redox_rust", input_bytes),
+        //     BenchmarkId::new("lz4_flex_rust_master", input_bytes),
         //     &comp_lz4,
-        //     |b, i| b.iter(|| lz4_compress::decompress(&i)),
+        //     |b, i| b.iter(|| lz4_flex_master::decompress(&i, input.len())),
         // );
-        // group.bench_with_input(
-        //     BenchmarkId::new("lz4_fear_rust", input_bytes),
-        //     &comp_lz4,
-        //     |b, i| b.iter(|| decompress_lz4_fear(&i)),
-        // );
+        group.bench_with_input(
+            BenchmarkId::new("lz4_redox_rust", input_bytes),
+            &comp_lz4,
+            |b, i| b.iter(|| lz4_compress::decompress(&i)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("lz4_fear_rust", input_bytes),
+            &comp_lz4,
+            |b, i| b.iter(|| decompress_lz4_fear(&i)),
+        );
 
-        // group.bench_with_input(
-        //     BenchmarkId::new("lz4_cpp", input_bytes),
-        //     &comp_lz4,
-        //     |b, i| b.iter(|| lz4_cpp_block_decompress(&i, input.len())),
-        // );
+        group.bench_with_input(
+            BenchmarkId::new("lz4_cpp", input_bytes),
+            &comp_lz4,
+            |b, i| b.iter(|| lz4_cpp_block_decompress(&i, input.len())),
+        );
 
-        // let comp_snap = compress_snap(&input);
-        // group.bench_with_input(BenchmarkId::new("snap", input_bytes), &comp_snap, |b, i| {
-        //     b.iter(|| decompress_snap(&i))
-        // });
+        let comp_snap = compress_snap(&input);
+        group.bench_with_input(BenchmarkId::new("snap", input_bytes), &comp_snap, |b, i| {
+            b.iter(|| decompress_snap(&i))
+        });
     }
 
     group.finish();
@@ -268,37 +268,37 @@ fn bench_frame_decompression_throughput(c: &mut Criterion) {
             &comp_lz4_indep,
             |b, i| b.iter(|| lz4_flex_frame_decompress(&i)),
         );
-        // group.bench_with_input(
-        //     BenchmarkId::new("lz4_flex_rust_linked", input_bytes),
-        //     &comp_lz4_linked,
-        //     |b, i| b.iter(|| lz4_flex_frame_decompress(&i)),
-        // );
         group.bench_with_input(
-            BenchmarkId::new("lz4_flex_master_rust_indep", input_bytes),
-            &comp_lz4_indep,
-            |b, i| b.iter(|| lz4_flex_master_frame_decompress(&i)),
+            BenchmarkId::new("lz4_flex_rust_linked", input_bytes),
+            &comp_lz4_linked,
+            |b, i| b.iter(|| lz4_flex_frame_decompress(&i)),
         );
+        // group.bench_with_input(
+        //     BenchmarkId::new("lz4_flex_master_rust_indep", input_bytes),
+        //     &comp_lz4_indep,
+        //     |b, i| b.iter(|| lz4_flex_master_frame_decompress(&i)),
+        // );
         // group.bench_with_input(
         //     BenchmarkId::new("lz4_flex_master_rust_linked", input_bytes),
         //     &comp_lz4_linked,
         //     |b, i| b.iter(|| lz4_flex_master_frame_decompress(&i)),
         // );
 
-        // group.bench_with_input(
-        //     BenchmarkId::new("lz4_cpp_indep", input_bytes),
-        //     &comp_lz4_indep,
-        //     |b, i| b.iter(|| lz4_cpp_frame_decompress(&i)),
-        // );
-        // group.bench_with_input(
-        //     BenchmarkId::new("lz4_cpp_linked", input_bytes),
-        //     &comp_lz4_linked,
-        //     |b, i| b.iter(|| lz4_cpp_frame_decompress(&i)),
-        // );
+        group.bench_with_input(
+            BenchmarkId::new("lz4_cpp_indep", input_bytes),
+            &comp_lz4_indep,
+            |b, i| b.iter(|| lz4_cpp_frame_decompress(&i)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("lz4_cpp_linked", input_bytes),
+            &comp_lz4_linked,
+            |b, i| b.iter(|| lz4_cpp_frame_decompress(&i)),
+        );
 
-        // let comp_snap = compress_snap_frame(&input);
-        // group.bench_with_input(BenchmarkId::new("snap", input_bytes), &comp_snap, |b, i| {
-        //     b.iter(|| decompress_snap_frame(&i))
-        // });
+        let comp_snap = compress_snap_frame(&input);
+        group.bench_with_input(BenchmarkId::new("snap", input_bytes), &comp_snap, |b, i| {
+            b.iter(|| decompress_snap_frame(&i))
+        });
     }
 
     group.finish();
@@ -326,29 +326,29 @@ fn bench_frame_compression_throughput(c: &mut Criterion) {
                 })
             },
         );
-        // group.bench_with_input(
-        //     BenchmarkId::new("lz4_flex_rust_linked", input_bytes),
-        //     &input,
-        //     |b, i| {
-        //         b.iter(|| {
-        //             let mut frame_info = lz4_flex::frame::FrameInfo::new();
-        //             frame_info.block_mode = lz4_flex::frame::BlockMode::Linked;
-        //             lz4_flex_frame_compress_with(frame_info, i)
-        //         })
-        //     },
-        // );
-
         group.bench_with_input(
-            BenchmarkId::new("lz4_flex_master_rust_indep", input_bytes),
+            BenchmarkId::new("lz4_flex_rust_linked", input_bytes),
             &input,
             |b, i| {
                 b.iter(|| {
-                    let mut frame_info = lz4_flex_master::frame::FrameInfo::new();
-                    frame_info.block_mode = lz4_flex_master::frame::BlockMode::Independent;
-                    lz4_flex_master_frame_compress_with(frame_info, i)
+                    let mut frame_info = lz4_flex::frame::FrameInfo::new();
+                    frame_info.block_mode = lz4_flex::frame::BlockMode::Linked;
+                    lz4_flex_frame_compress_with(frame_info, i)
                 })
             },
         );
+
+        // group.bench_with_input(
+        //     BenchmarkId::new("lz4_flex_master_rust_indep", input_bytes),
+        //     &input,
+        //     |b, i| {
+        //         b.iter(|| {
+        //             let mut frame_info = lz4_flex_master::frame::FrameInfo::new();
+        //             frame_info.block_mode = lz4_flex_master::frame::BlockMode::Independent;
+        //             lz4_flex_master_frame_compress_with(frame_info, i)
+        //         })
+        //     },
+        // );
         // group.bench_with_input(
         //     BenchmarkId::new("lz4_flex_master_rust_linked", input_bytes),
         //     &input,
@@ -361,20 +361,20 @@ fn bench_frame_compression_throughput(c: &mut Criterion) {
         //     },
         // );
 
-        // group.bench_with_input(
-        //     BenchmarkId::new("lz4_cpp_indep", input_bytes),
-        //     &input,
-        //     |b, i| b.iter(|| lz4_cpp_frame_compress(i, true)),
-        // );
-        // group.bench_with_input(
-        //     BenchmarkId::new("lz4_cpp_linked", input_bytes),
-        //     &input,
-        //     |b, i| b.iter(|| lz4_cpp_frame_compress(i, false)),
-        // );
+        group.bench_with_input(
+            BenchmarkId::new("lz4_cpp_indep", input_bytes),
+            &input,
+            |b, i| b.iter(|| lz4_cpp_frame_compress(i, true)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("lz4_cpp_linked", input_bytes),
+            &input,
+            |b, i| b.iter(|| lz4_cpp_frame_compress(i, false)),
+        );
 
-        // group.bench_with_input(BenchmarkId::new("snap", input_bytes), &input, |b, i| {
-        //     b.iter(|| compress_snap_frame(i))
-        // });
+        group.bench_with_input(BenchmarkId::new("snap", input_bytes), &input, |b, i| {
+            b.iter(|| compress_snap_frame(i))
+        });
     }
 
     group.finish();

--- a/fuzz/fuzz_targets/fuzz_decomp_corrupt_block.rs
+++ b/fuzz/fuzz_targets/fuzz_decomp_corrupt_block.rs
@@ -1,15 +1,16 @@
 #![no_main]
-use std::convert::TryInto;
 use libfuzzer_sys::fuzz_target;
+use std::convert::TryInto;
 
-use lz4_flex::decompress_size_prepended;
+use lz4_flex::block::{decompress_size_prepended, decompress_size_prepended_with_dict};
 fuzz_target!(|data: &[u8]| {
-	if data.len() >= 4 {
-		let size = u32::from_le_bytes(data[0..4].try_into().unwrap());
-		if size > 20_000_000 {
-			return;
-		}
-	}
+    if data.len() >= 4 {
+        let size = u32::from_le_bytes(data[0..4].try_into().unwrap());
+        if size > 20_000_000 {
+            return;
+        }
+    }
     // should not panic
     let _ = decompress_size_prepended(&data);
+    let _ = decompress_size_prepended_with_dict(&data, &data);
 });

--- a/src/block/decompress.rs
+++ b/src/block/decompress.rs
@@ -1,7 +1,7 @@
 //! The decompression algorithm.
 use crate::block::DecompressError;
-use crate::block::Sink;
 use crate::block::MINMATCH;
+use crate::sink::{Sink, SliceSink, VecSink};
 use alloc::vec::Vec;
 
 /// Copies data to output_ptr by self-referential copy from start and match_length
@@ -171,36 +171,12 @@ fn does_token_fit(token: u8) -> bool {
 }
 
 /// Decompress all bytes of `input` into `output`.
-/// `output` should be preallocated with a size of of the uncompressed data.
-#[inline]
-pub fn decompress_into(
-    input: &[u8],
-    output: &mut [u8],
-    output_pos: usize,
-) -> Result<usize, DecompressError> {
-    decompress_internal::<false>(input, &mut (output, output_pos).into(), b"")
-}
-
-/// Decompress all bytes of `input` into `output`.
 ///
 /// Returns the number of bytes written (decompressed) into `output`.
 #[inline]
-pub fn decompress_into_with_dict(
+pub(crate) fn decompress_internal<SINK: Sink, const USE_DICT: bool>(
     input: &[u8],
-    output: &mut [u8],
-    output_pos: usize,
-    ext_dict: &[u8],
-) -> Result<usize, DecompressError> {
-    decompress_internal::<true>(input, &mut (output, output_pos).into(), ext_dict)
-}
-
-/// Decompress all bytes of `input` into `output`.
-///
-/// Returns the number of bytes written (decompressed) into `output`.
-#[inline]
-fn decompress_internal<const USE_DICT: bool>(
-    input: &[u8],
-    output: &mut Sink,
+    output: &mut SINK,
     ext_dict: &[u8],
 ) -> Result<usize, DecompressError> {
     #[cfg(not(feature = "checked-decode"))]
@@ -211,9 +187,9 @@ fn decompress_internal<const USE_DICT: bool>(
         }
     }
 
-    let output_base = output.output.as_mut_ptr();
+    let output_base = unsafe { output.base_mut_ptr() };
     let output_end = unsafe { output_base.add(output.capacity()) };
-    let output_start_pos_ptr = output.as_mut_ptr();
+    let output_start_pos_ptr = unsafe { output.pos_mut_ptr() };
     let mut output_ptr = output_start_pos_ptr;
     let mut input_pos = 0;
 
@@ -286,7 +262,7 @@ fn decompress_internal<const USE_DICT: bool>(
             let mut start_ptr = unsafe { output_ptr.sub(offset) };
             #[cfg(feature = "checked-decode")]
             {
-                if unsafe { start_ptr.add(ext_dict.len()) } < output_base {
+                if offset == 0 || unsafe { start_ptr.add(ext_dict.len()) } < output_base {
                     return Err(DecompressError::OffsetOutOfBounds);
                 }
             }
@@ -399,7 +375,7 @@ fn decompress_internal<const USE_DICT: bool>(
         // We'll do a bounds check in checked-decode.
         #[cfg(feature = "checked-decode")]
         {
-            if unsafe { start_ptr.add(ext_dict.len()) } < output_base {
+            if offset == 0 || unsafe { start_ptr.add(ext_dict.len()) } < output_base {
                 return Err(DecompressError::OffsetOutOfBounds);
             }
             if unsafe { output_ptr.add(match_length) } > output_end {
@@ -429,7 +405,29 @@ fn decompress_internal<const USE_DICT: bool>(
             duplicate(&mut output_ptr, output_end, start_ptr, match_length);
         }
     }
-    Ok(unsafe { output_ptr.offset_from(output_start_pos_ptr) as usize })
+    unsafe {
+        output.set_pos(output_ptr.offset_from(output_base) as usize);
+        Ok(output_ptr.offset_from(output_start_pos_ptr) as usize)
+    }
+}
+
+/// Decompress all bytes of `input` into `output`.
+/// `output` should be preallocated with a size of of the uncompressed data.
+#[inline]
+pub fn decompress_into(input: &[u8], output: &mut [u8]) -> Result<usize, DecompressError> {
+    decompress_internal::<_, false>(input, &mut SliceSink::new(output, 0), b"")
+}
+
+/// Decompress all bytes of `input` into `output`.
+///
+/// Returns the number of bytes written (decompressed) into `output`.
+#[inline]
+pub fn decompress_into_with_dict(
+    input: &[u8],
+    output: &mut [u8],
+    ext_dict: &[u8],
+) -> Result<usize, DecompressError> {
+    decompress_internal::<_, true>(input, &mut SliceSink::new(output, 0), ext_dict)
 }
 
 /// Decompress all bytes of `input` into a new vec. The first 4 bytes are the uncompressed size in little endian.
@@ -444,22 +442,15 @@ pub fn decompress_size_prepended(input: &[u8]) -> Result<Vec<u8>, DecompressErro
 #[inline]
 pub fn decompress(input: &[u8], uncompressed_size: usize) -> Result<Vec<u8>, DecompressError> {
     // Allocate a vector to contain the decompressed stream.
-    // We may wildcopy out of bounds, so the vector needs to have additional capacity
     let mut vec: Vec<u8> = Vec::with_capacity(uncompressed_size);
-    unsafe {
-        vec.set_len(uncompressed_size);
-    }
-    let decomp_len = decompress_into(input, &mut vec, 0)?;
+    let decomp_len =
+        decompress_internal::<_, false>(input, &mut VecSink::new(&mut vec, 0, 0), b"")?;
     if decomp_len != uncompressed_size {
         return Err(DecompressError::UncompressedSizeDiffers {
             expected: uncompressed_size,
             actual: decomp_len,
         });
     }
-    unsafe {
-        vec.set_len(uncompressed_size);
-    }
-
     Ok(vec)
 }
 
@@ -482,22 +473,15 @@ pub fn decompress_with_dict(
     ext_dict: &[u8],
 ) -> Result<Vec<u8>, DecompressError> {
     // Allocate a vector to contain the decompressed stream.
-    // We may wildcopy out of bounds, so the vector needs to have additional capacity
     let mut vec: Vec<u8> = Vec::with_capacity(uncompressed_size);
-    unsafe {
-        vec.set_len(uncompressed_size);
-    }
-    let decomp_len = decompress_into_with_dict(input, &mut vec, 0, ext_dict)?;
+    let decomp_len =
+        decompress_internal::<_, true>(input, &mut VecSink::new(&mut vec, 0, 0), ext_dict)?;
     if decomp_len != uncompressed_size {
         return Err(DecompressError::UncompressedSizeDiffers {
             expected: uncompressed_size,
             actual: decomp_len,
         });
     }
-    unsafe {
-        vec.set_len(uncompressed_size);
-    }
-
     Ok(vec)
 }
 

--- a/src/block/decompress_safe.rs
+++ b/src/block/decompress_safe.rs
@@ -3,8 +3,9 @@
 use core::convert::TryInto;
 
 use crate::block::DecompressError;
-use crate::block::Sink;
 use crate::block::MINMATCH;
+use crate::sink::Sink;
+use crate::sink::SliceSink;
 use alloc::vec::Vec;
 
 /// Read an integer LSIC (linear small integer code) encoded.
@@ -78,39 +79,14 @@ fn does_token_fit(token: u8) -> bool {
 }
 
 /// Decompress all bytes of `input` into `output`.
-/// `output` should be preallocated with a size of of the uncompressed data.
-#[inline]
-pub fn decompress_into(
-    input: &[u8],
-    output: &mut [u8],
-    output_pos: usize,
-) -> Result<usize, DecompressError> {
-    decompress_internal::<false>(input, &mut (output, output_pos).into(), b"")
-}
-
-/// Decompress all bytes of `input` into `output`.
 ///
 /// Returns the number of bytes written (decompressed) into `output`.
-#[inline]
-pub fn decompress_into_with_dict(
+#[inline(always)] // (always) necessary to get the best performance in non LTO builds
+pub(crate) fn decompress_internal<SINK: Sink, const USE_DICT: bool>(
     input: &[u8],
-    output: &mut [u8],
-    output_pos: usize,
+    output: &mut SINK,
     ext_dict: &[u8],
 ) -> Result<usize, DecompressError> {
-    decompress_internal::<true>(input, &mut (output, output_pos).into(), ext_dict)
-}
-
-/// Decompress all bytes of `input` into `output`.
-///
-/// Returns the number of bytes written (decompressed) into `output`.
-#[inline]
-fn decompress_internal<const USE_DICT: bool>(
-    input: &[u8],
-    output: &mut Sink,
-    ext_dict: &[u8],
-) -> Result<usize, DecompressError> {
-    // Decode into our vector.
     let mut input_pos = 0;
     let initial_output_pos = output.pos();
 
@@ -149,11 +125,7 @@ fn decompress_internal<const USE_DICT: bool>(
             // Copy the literal
             // The literal is at max 14 bytes, and the is_safe_distance check assures
             // that we are far away enough from the end so we can safely copy 16 bytes
-            {
-                let pos = output.pos();
-                output.output[pos..pos + 16].copy_from_slice(&input[input_pos..input_pos + 16]);
-            }
-            output.pos += literal_length;
+            output.extend_from_slice_wild(&input[input_pos..input_pos + 16], literal_length);
             input_pos += literal_length;
 
             let offset = read_u16(input, &mut input_pos)? as usize;
@@ -170,20 +142,16 @@ fn decompress_internal<const USE_DICT: bool>(
             }
 
             // In this branch we know that match_length is at most 18 (14 + MINMATCH).
-            // But the blocks can overlap, so make sure they are at least 20 bytes apart
+            // But the blocks can overlap, so make sure they are at least 18 bytes apart
             // to enable an optimized copy of 18 bytes.
             let (start, did_overflow) = output.pos().overflowing_sub(offset);
             if did_overflow {
                 return Err(DecompressError::OffsetOutOfBounds);
             }
             if offset >= match_length {
-                output.output.copy_within(start..start + 18, output.pos());
-                output.pos += match_length;
+                output.extend_from_within_wild(start, 18, match_length);
             } else {
-                for i in start..start + match_length {
-                    let b = output.as_slice()[i];
-                    output.push(b);
-                }
+                output.extend_from_within_overlapping(start, match_length)
             }
 
             continue;
@@ -204,9 +172,9 @@ fn decompress_internal<const USE_DICT: bool>(
                 return Err(DecompressError::LiteralOutOfBounds);
             }
             #[cfg(feature = "checked-decode")]
-            if output.pos + literal_length > output.capacity() {
+            if output.pos() + literal_length > output.capacity() {
                 return Err(DecompressError::OutputTooSmall {
-                    expected: output.pos + literal_length,
+                    expected: output.pos() + literal_length,
                     actual: output.capacity(),
                 });
             }
@@ -237,9 +205,9 @@ fn decompress_internal<const USE_DICT: bool>(
         }
 
         #[cfg(feature = "checked-decode")]
-        if output.pos + match_length > output.capacity() {
+        if output.pos() + match_length > output.capacity() {
             return Err(DecompressError::OutputTooSmall {
-                expected: output.pos + match_length,
+                expected: output.pos() + match_length,
                 actual: output.capacity(),
             });
         }
@@ -260,13 +228,13 @@ fn decompress_internal<const USE_DICT: bool>(
 
 #[inline]
 fn copy_from_dict(
-    output: &mut Sink,
+    output: &mut impl Sink,
     ext_dict: &[u8],
     offset: usize,
     match_length: usize,
 ) -> Result<usize, DecompressError> {
     // If we're here we know offset > output.pos
-    debug_assert!(offset > output.pos);
+    debug_assert!(offset > output.pos());
     let (dict_offset, did_overflow) = ext_dict.len().overflowing_sub(offset - output.pos());
     if did_overflow {
         return Err(DecompressError::OffsetOutOfBounds);
@@ -281,7 +249,7 @@ fn copy_from_dict(
 /// Extends output by self-referential copies
 #[inline(always)] // (always) necessary otherwise compiler fails to inline it
 fn duplicate_slice(
-    output: &mut Sink,
+    output: &mut impl Sink,
     offset: usize,
     match_length: usize,
 ) -> Result<(), DecompressError> {
@@ -293,18 +261,15 @@ fn duplicate_slice(
         if did_overflow_1 {
             return Err(DecompressError::OffsetOutOfBounds);
         }
-        let output_end = output.pos() + match_length;
-        if output_end + (16 - 1) <= output.capacity() {
-            for i in (start..start + match_length).step_by(16) {
-                output.output.copy_within(i..i + 16, output.pos());
-                output.pos += 16;
+        match match_length {
+            0..=32 if output.pos() + 32 <= output.capacity() => {
+                output.extend_from_within_wild(start, 32, match_length)
             }
-        } else {
-            output
-                .output
-                .copy_within(start..start + match_length, output.pos());
+            33..=64 if output.pos() + 64 <= output.capacity() => {
+                output.extend_from_within_wild(start, 64, match_length)
+            }
+            _ => output.extend_from_within(start, match_length),
         }
-        output.set_pos(output_end);
     }
     Ok(())
 }
@@ -312,7 +277,7 @@ fn duplicate_slice(
 /// self-referential copy for the case data start (end of output - offset) + match_length overlaps into output
 #[inline]
 fn duplicate_overlapping_slice(
-    sink: &mut Sink,
+    sink: &mut impl Sink,
     offset: usize,
     match_length: usize,
 ) -> Result<(), DecompressError> {
@@ -322,17 +287,31 @@ fn duplicate_overlapping_slice(
         return Err(DecompressError::OffsetOutOfBounds);
     }
     if offset == 1 {
-        let val = sink.as_slice()[start];
-        let dest = sink.pos();
-        sink.output[dest..dest + match_length].fill(val);
-        sink.pos += match_length;
+        let val = sink.filled_slice()[start];
+        sink.extend_with_fill(val, match_length);
     } else {
-        for i in start..start + match_length {
-            let b = sink.as_slice()[i];
-            sink.push(b);
-        }
+        sink.extend_from_within_overlapping(start, match_length);
     }
     Ok(())
+}
+
+/// Decompress all bytes of `input` into `output`.
+/// `output` should be preallocated with a size of of the uncompressed data.
+#[inline]
+pub fn decompress_into(input: &[u8], output: &mut [u8]) -> Result<usize, DecompressError> {
+    decompress_internal::<_, false>(input, &mut SliceSink::new(output, 0), b"")
+}
+
+/// Decompress all bytes of `input` into `output`.
+///
+/// Returns the number of bytes written (decompressed) into `output`.
+#[inline]
+pub fn decompress_into_with_dict(
+    input: &[u8],
+    output: &mut [u8],
+    ext_dict: &[u8],
+) -> Result<usize, DecompressError> {
+    decompress_internal::<_, true>(input, &mut SliceSink::new(output, 0), ext_dict)
 }
 
 /// Decompress all bytes of `input` into a new vec. The first 4 bytes are the uncompressed size in litte endian.
@@ -346,17 +325,16 @@ pub fn decompress_size_prepended(input: &[u8]) -> Result<Vec<u8>, DecompressErro
 /// Decompress all bytes of `input` into a new vec.
 #[inline]
 pub fn decompress(input: &[u8], uncompressed_size: usize) -> Result<Vec<u8>, DecompressError> {
-    // Allocate a vector to contain the decompressed stream.
-    let mut vec: Vec<u8> = Vec::with_capacity(uncompressed_size);
-    vec.resize(uncompressed_size, 0);
-    let decomp_len = decompress_into(input, &mut vec, 0)?;
+    let mut decompressed: Vec<u8> = vec![0; uncompressed_size];
+    let decomp_len =
+        decompress_internal::<_, false>(input, &mut SliceSink::new(&mut decompressed, 0), b"")?;
     if decomp_len != uncompressed_size {
         return Err(DecompressError::UncompressedSizeDiffers {
             expected: uncompressed_size,
             actual: decomp_len,
         });
     }
-    Ok(vec)
+    Ok(decompressed)
 }
 
 /// Decompress all bytes of `input` into a new vec. The first 4 bytes are the uncompressed size in little endian.
@@ -377,17 +355,16 @@ pub fn decompress_with_dict(
     uncompressed_size: usize,
     ext_dict: &[u8],
 ) -> Result<Vec<u8>, DecompressError> {
-    // Allocate a vector to contain the decompressed stream.
-    let mut vec: Vec<u8> = Vec::with_capacity(uncompressed_size);
-    vec.resize(uncompressed_size, 0);
-    let decomp_len = decompress_into_with_dict(input, &mut vec, 0, ext_dict)?;
+    let mut decompressed: Vec<u8> = vec![0; uncompressed_size];
+    let decomp_len =
+        decompress_internal::<_, true>(input, &mut SliceSink::new(&mut decompressed, 0), ext_dict)?;
     if decomp_len != uncompressed_size {
         return Err(DecompressError::UncompressedSizeDiffers {
             expected: uncompressed_size,
             actual: decomp_len,
         });
     }
-    Ok(vec)
+    Ok(decompressed)
 }
 
 #[cfg(test)]

--- a/src/frame/compress.rs
+++ b/src/frame/compress.rs
@@ -5,9 +5,12 @@ use std::{
 };
 use twox_hash::XxHash32;
 
-use crate::block::{
-    compress::compress_internal,
-    hashtable::{HashTable, HashTableU32},
+use crate::{
+    block::{
+        compress::compress_internal,
+        hashtable::{HashTable, HashTableU32},
+    },
+    sink::vec_sink_for_compression,
 };
 
 use super::header::{BlockInfo, BlockMode, FrameInfo, BLOCK_INFO_SIZE, MAX_FRAME_INFO_SIZE};
@@ -60,7 +63,7 @@ pub struct FrameEncoder<W: io::Write> {
     ext_dict_offset: usize,
     /// Length of external dictionary
     ext_dict_len: usize,
-    /// Counter of bytes already compressed to the compression_table (applicable in Linked block mode)
+    /// Counter of bytes already compressed to the compression_table
     /// _Not_ the same as `content_len` as this is reset every to 2GB.
     src_stream_offset: usize,
     /// Encoder table
@@ -231,29 +234,23 @@ impl<W: io::Write> FrameEncoder<W> {
         // the contents of the block are between src_start and src_end
         let src = &input[self.src_start..];
 
-        // ensure dst has enough len for the compressed output
         let dst_required_size = crate::block::compress::get_maximum_output_size(src.len());
-        if self.dst.len() < dst_required_size {
-            vec_set_len(&mut self.dst, dst_required_size)
-        }
 
         let compress_result = if self.ext_dict_len != 0 {
             debug_assert_eq!(self.frame_info.block_mode, BlockMode::Linked);
-            compress_internal::<_, true>(
+            compress_internal::<_, _, true>(
                 input,
                 self.src_start,
-                &mut self.dst[..],
-                0,
+                &mut vec_sink_for_compression(&mut self.dst, 0, 0, dst_required_size),
                 &mut self.compression_table,
                 &self.src[self.ext_dict_offset..self.ext_dict_offset + self.ext_dict_len],
                 self.src_stream_offset,
             )
         } else {
-            compress_internal::<_, false>(
+            compress_internal::<_, _, false>(
                 input,
                 self.src_start,
-                &mut self.dst[..],
-                0,
+                &mut vec_sink_for_compression(&mut self.dst, 0, 0, dst_required_size),
                 &mut self.compression_table,
                 b"",
                 self.src_stream_offset,
@@ -383,25 +380,6 @@ impl<W: fmt::Debug + io::Write> fmt::Debug for FrameEncoder<W> {
             .field("ext_dict_len", &self.ext_dict_len)
             .field("src_stream_offset", &self.src_stream_offset)
             .finish()
-    }
-}
-
-/// Similar to set_len but panics if the vec doesn't have enough capacity.
-#[cfg(feature = "safe-encode")]
-#[inline]
-fn vec_set_len(v: &mut Vec<u8>, new_len: usize) {
-    // The assert isn't strictly needed but we want to assert the same behavior as the unsafe version
-    assert!(new_len <= v.capacity());
-    v.resize(new_len, 0);
-}
-
-/// Similar to set_len but panics if the vec doesn't have enough capacity.
-#[cfg(not(feature = "safe-encode"))]
-#[inline]
-fn vec_set_len(v: &mut Vec<u8>, new_len: usize) {
-    assert!(new_len <= v.capacity());
-    unsafe {
-        v.set_len(new_len);
     }
 }
 

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -4,7 +4,9 @@
 
 use std::{fmt, io};
 
+#[cfg_attr(feature = "safe-encode", forbid(unsafe_code))]
 pub(crate) mod compress;
+#[cfg_attr(feature = "safe-decode", forbid(unsafe_code))]
 pub(crate) mod decompress;
 pub(crate) mod header;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,3 +89,9 @@ pub mod frame;
 pub use block::{compress, compress_into, compress_prepend_size};
 
 pub use block::{decompress, decompress_into, decompress_size_prepended};
+
+#[cfg_attr(
+    all(feature = "safe-encode", feature = "safe-decode"),
+    forbid(unsafe_code)
+)]
+pub(crate) mod sink;

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -7,6 +7,7 @@ use core::mem::MaybeUninit;
 /// bytes at `vec[offset..offset+required_capacity]`.
 /// It can be either a `SliceSink` (pre-filling the vec with zeroes if necessary)
 /// when the `safe-decode` feature is enabled, or `VecSink` otherwise.
+/// The argument `pos` defines the initial output position in the Sink.
 #[inline]
 pub fn vec_sink_for_compression<'a>(
     vec: &'a mut Vec<u8>,
@@ -31,6 +32,7 @@ pub fn vec_sink_for_compression<'a>(
 /// bytes at `vec[offset..offset+required_capacity]`.
 /// It can be either a `SliceSink` (pre-filling the vec with zeroes if necessary)
 /// when the `safe-decode` feature is enabled, or `VecSink` otherwise.
+/// The argument `pos` defines the initial output position in the Sink.
 #[inline]
 pub fn vec_sink_for_decompression<'a>(
     vec: &'a mut Vec<u8>,
@@ -139,6 +141,9 @@ pub struct SliceSink<'a> {
 
 impl<'a> SliceSink<'a> {
     /// Creates a `Sink` backed by the given byte slice.
+    /// `pos` defines the initial output position in the Sink.
+    /// # Panics
+    /// Panics if `pos` is out of bounds.
     #[inline]
     pub fn new(output: &'a mut [u8], pos: usize) -> Self {
         // SAFETY: Caller guarantees that all elements of `output` are initialized.
@@ -231,9 +236,12 @@ pub struct VecSink<'a> {
 #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
 impl<'a> VecSink<'a> {
     /// Creates a `Sink` backed by the Vec bytes at `vec[offset..vec.capacity()]`.
+    /// `pos` defines the initial output position (counted from `offset`) in the Sink.
     /// Note that the bytes at `vec[output.len()..]` are actually uninitialized and will
     /// not be readable until written.
     /// When the `Sink` is dropped the Vec len will be adjusted to `offset` + `Sink.pos`.
+    /// # Panics
+    /// Panics if `pos` is out of bounds.
     #[inline]
     pub fn new(output: &'a mut Vec<u8>, offset: usize, pos: usize) -> VecSink<'a> {
         // The truncation also works as bounds checking for offset and pos.

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,0 +1,384 @@
+#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+use alloc::vec::Vec;
+#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+use core::mem::MaybeUninit;
+
+/// Returns a Sink implementation appropriate for outputing up to `required_capacity`
+/// bytes at `vec[offset..offset+required_capacity]`.
+/// It can be either a `SliceSink` (pre-filling the vec with zeroes if necessary)
+/// when the `safe-decode` feature is enabled, or `VecSink` otherwise.
+#[inline]
+pub fn vec_sink_for_compression<'a>(
+    vec: &'a mut Vec<u8>,
+    offset: usize,
+    pos: usize,
+    required_capacity: usize,
+) -> impl Sink + 'a {
+    #[cfg(not(feature = "safe-encode"))]
+    return {
+        assert!(vec.capacity() >= offset + required_capacity);
+        VecSink::new(vec, offset, pos)
+    };
+
+    #[cfg(feature = "safe-encode")]
+    return {
+        vec.resize(offset + required_capacity, 0);
+        SliceSink::new(&mut vec[offset..], pos)
+    };
+}
+
+/// Returns a Sink implementation appropriate for outputing up to `required_capacity`
+/// bytes at `vec[offset..offset+required_capacity]`.
+/// It can be either a `SliceSink` (pre-filling the vec with zeroes if necessary)
+/// when the `safe-decode` feature is enabled, or `VecSink` otherwise.
+#[inline]
+pub fn vec_sink_for_decompression<'a>(
+    vec: &'a mut Vec<u8>,
+    offset: usize,
+    pos: usize,
+    required_capacity: usize,
+) -> impl Sink + 'a {
+    #[cfg(not(feature = "safe-decode"))]
+    return {
+        assert!(vec.capacity() >= offset + required_capacity);
+        crate::sink::VecSink::new(vec, offset, pos)
+    };
+
+    #[cfg(feature = "safe-decode")]
+    return {
+        vec.resize(offset + required_capacity, 0);
+        SliceSink::new(&mut vec[offset..], pos)
+    };
+}
+
+/// Sink is used as target to de/compress data into a preallocated and possibly uninitialized memory space.
+///
+/// # Handling of Capacity
+/// Extend methods will panic if there's insufficient capacity left in the Sink.
+///
+/// # Invariants
+///   - Bytes `[..pos()]` are always initialized.
+pub trait Sink {
+    /// The bytes that are considered filled.
+    fn filled_slice(&self) -> &[u8];
+
+    /// The current position (aka. len) of the the Sink.
+    fn pos(&self) -> usize;
+
+    /// The total capacity of the Sink.
+    fn capacity(&self) -> usize;
+
+    /// Forces the length of the vector to `new_pos`.
+    /// The caller is responsible for ensuring all bytes up to `new_pos` are properly initialized.
+    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+    unsafe fn set_pos(&mut self, new_pos: usize);
+
+    /// Returns a raw ptr to the first byte of the Sink. Analogous to `[0..].as_ptr()`.
+    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+    unsafe fn base_mut_ptr(&mut self) -> *mut u8;
+
+    /// Returns a raw ptr to the first unfilled byte of the Sink. Analogous to `[pos..].as_ptr()`.
+    #[inline]
+    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+    unsafe fn pos_mut_ptr(&mut self) -> *mut u8 {
+        self.base_mut_ptr().add(self.pos()) as *mut u8
+    }
+
+    /// Pushes a byte to the end of the Sink.
+    #[inline]
+    fn push(&mut self, byte: u8) {
+        self.extend_from_slice(&[byte])
+    }
+
+    /// Pushes `len` elements of `byte` to the end of the Sink.
+    fn extend_with_fill(&mut self, byte: u8, len: usize);
+
+    /// Extends the Sink with `data` but only advances the sink by `copy_len`.
+    /// # Panics
+    /// Panics if `copy_len` > `data.len()`
+    fn extend_from_slice_wild(&mut self, data: &[u8], copy_len: usize);
+
+    /// Extends the Sink with `data`.
+    #[inline]
+    fn extend_from_slice(&mut self, data: &[u8]) {
+        self.extend_from_slice_wild(data, data.len())
+    }
+
+    /// Copies `wild_len` bytes starting from `start` to the end of the Sink.
+    /// The position of the Sink is increased by `copy_len` NOT `wild_len`;
+    /// # Panics
+    /// Panics if `start + copy_len` > `pos`.
+    /// Panics if `copy_len` > `wild_len`.
+    fn extend_from_within_wild(&mut self, start: usize, wild_len: usize, copy_len: usize);
+
+    /// Copies `len` bytes starting from `start` to the end of the Sink.
+    /// # Panics
+    /// Panics if `start` >= `pos`.
+    #[inline]
+    fn extend_from_within(&mut self, start: usize, len: usize) {
+        self.extend_from_within_wild(start, len, len)
+    }
+
+    /// Copies `len` bytes starting from `start` to the end of the Sink.
+    /// Contrary to `extend_from_within`, the copy output can overlap with
+    /// the copy source bytes.
+    /// In addition, a copy with `start` == `pos` is valid and will
+    /// fill the sink `len` zero bytes.
+    /// # Panics
+    /// Panics if `start` > `pos`.
+    fn extend_from_within_overlapping(&mut self, start: usize, len: usize);
+}
+
+/// A Sink baked by a &[u8]
+pub struct SliceSink<'a> {
+    /// The working slice, which may contain uninitialized bytes
+    output: &'a mut [u8],
+    /// Number of bytes in start of `output` guaranteed to be initialized
+    pos: usize,
+}
+
+impl<'a> SliceSink<'a> {
+    /// Creates a `Sink` backed by the given byte slice.
+    #[inline]
+    pub fn new(output: &'a mut [u8], pos: usize) -> Self {
+        // SAFETY: Caller guarantees that all elements of `output` are initialized.
+        let _ = &mut output[..pos]; // bounds check pos
+        SliceSink { output, pos }
+    }
+}
+
+impl<'a> Sink for SliceSink<'a> {
+    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+    unsafe fn base_mut_ptr(&mut self) -> *mut u8 {
+        self.output.as_mut_ptr()
+    }
+
+    #[inline]
+    fn filled_slice(&self) -> &[u8] {
+        &self.output[..self.pos]
+    }
+
+    #[inline]
+    fn pos(&self) -> usize {
+        self.pos
+    }
+
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.output.len()
+    }
+
+    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+    #[inline]
+    unsafe fn set_pos(&mut self, new_pos: usize) {
+        debug_assert!(new_pos <= self.capacity());
+        self.pos = new_pos;
+    }
+
+    #[inline]
+    fn extend_with_fill(&mut self, byte: u8, len: usize) {
+        self.output[self.pos..self.pos + len].fill(byte);
+        self.pos += len;
+    }
+
+    #[inline]
+    fn extend_from_slice_wild(&mut self, data: &[u8], copy_len: usize) {
+        assert!(copy_len <= data.len());
+        self.output[self.pos..self.pos + data.len()].copy_from_slice(data);
+        self.pos += copy_len;
+    }
+
+    #[inline]
+    fn extend_from_within_wild(&mut self, start: usize, wild_len: usize, copy_len: usize) {
+        // Safety checks so that set_pos later don't expose uninitialized data
+        assert!(copy_len <= wild_len);
+        assert!(start + copy_len <= self.pos);
+        self.output.copy_within(start..start + wild_len, self.pos);
+        self.pos += copy_len;
+    }
+
+    #[inline]
+    fn extend_from_within_overlapping(&mut self, start: usize, len: usize) {
+        // Sink safety invariant guarantees that the first `pos` items are always initialized.
+        assert!(start <= self.pos);
+        let offset = self.pos - start;
+        let out = &mut self.output[start..self.pos + len];
+        out[offset] = 0; // ensures that a copy w/ start == pos becomes a zero fill
+        for i in offset..out.len() {
+            out[i] = out[i - offset];
+        }
+        self.pos += len;
+    }
+}
+
+#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+/// A sink backed by a Vec<u8>
+///
+/// Due to the intricacies of uninitialized memory in Rust this
+/// implementation requires using unsafe code even though it is
+/// fully bounds checked and never exposes uninitialized bytes.
+pub struct VecSink<'a> {
+    /// The backing vec
+    output: &'a mut Vec<u8>,
+    /// The output base ptr, a valid pointer within `output` data
+    output_ptr: *mut u8,
+    /// Number of bytes written after `output_ptr`
+    pos: usize,
+    /// Number of bytes available after `output_ptr`
+    capacity: usize,
+}
+
+#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+impl<'a> VecSink<'a> {
+    /// Creates a `Sink` backed by the Vec bytes at `vec[offset..vec.capacity()]`.
+    /// Note that the bytes at `vec[output.len()..]` are actually uninitialized and will
+    /// not be readable until written.
+    /// When the `Sink` is dropped the Vec len will be adjusted to `offset` + `Sink.pos`.
+    #[inline]
+    pub fn new(output: &'a mut Vec<u8>, offset: usize, pos: usize) -> VecSink<'a> {
+        // The truncation also works as bounds checking for offset and pos.
+        output.truncate(offset + pos);
+        VecSink {
+            capacity: output.capacity() - offset,
+            output_ptr: unsafe { output.as_mut_ptr().add(offset) },
+            output,
+            pos,
+        }
+    }
+}
+#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+impl<'a> VecSink<'a> {
+    #[inline]
+    fn buffer_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        // SAFETY: VecSink output_ptr points to at least capacity bytes in length
+        unsafe {
+            core::slice::from_raw_parts_mut(self.output_ptr as *mut MaybeUninit<u8>, self.capacity)
+        }
+    }
+}
+
+#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+impl<'a> Sink for VecSink<'a> {
+    unsafe fn base_mut_ptr(&mut self) -> *mut u8 {
+        self.output_ptr
+    }
+
+    #[inline]
+    fn filled_slice(&self) -> &[u8] {
+        // SAFETY: Sink safety invariant is that all bytes up to pos are initialized.
+        debug_assert!(self.pos <= self.capacity);
+        unsafe { core::slice::from_raw_parts(self.output_ptr, self.pos) }
+    }
+
+    #[inline]
+    fn pos(&self) -> usize {
+        self.pos
+    }
+
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    #[inline]
+    unsafe fn set_pos(&mut self, new_pos: usize) {
+        self.pos = new_pos
+    }
+
+    #[inline]
+    fn extend_with_fill(&mut self, byte: u8, len: usize) {
+        let pos = self.pos;
+        self.buffer_mut()[pos..pos + len].fill(MaybeUninit::new(byte));
+        self.pos += len;
+    }
+
+    #[inline]
+    fn extend_from_slice_wild(&mut self, data: &[u8], copy_len: usize) {
+        assert!(copy_len <= data.len());
+        let pos = self.pos;
+        self.buffer_mut()[pos..pos + data.len()].copy_from_slice(slice_as_uninit_ref(data));
+        self.pos += copy_len;
+    }
+
+    #[inline]
+    fn extend_from_within_wild(&mut self, start: usize, wild_len: usize, copy_len: usize) {
+        // Safety checks so that pos adjustment doesn't expose uninitialized data
+        assert!(copy_len <= wild_len);
+        assert!(start + copy_len <= self.pos);
+        let pos = self.pos;
+        self.buffer_mut().copy_within(start..start + wild_len, pos);
+        self.pos += copy_len;
+    }
+
+    #[inline]
+    fn extend_from_within_overlapping(&mut self, start: usize, len: usize) {
+        // Sink safety invariant guarantees that the first `pos` items are always initialized.
+        assert!(start <= self.pos);
+        let offset = self.pos - start;
+        let pos = self.pos;
+        let out = &mut self.buffer_mut()[start..pos + len];
+        out[offset] = MaybeUninit::new(0); // ensures that a copy w/ start == pos becomes a zero fill
+        for i in offset..out.len() {
+            out[i] = out[i - offset];
+        }
+        self.pos += len;
+    }
+}
+
+#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+impl<'a> Drop for VecSink<'a> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            let offset = self.output_ptr.offset_from(self.output.as_ptr()) as usize;
+            self.output.set_len(offset + self.pos);
+        }
+    }
+}
+
+#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+#[inline]
+fn slice_as_uninit_ref(slice: &[u8]) -> &[MaybeUninit<u8>] {
+    // SAFETY: `&[T]` is guaranteed to have the same layout as `&[MaybeUninit<T>]`
+    unsafe { core::slice::from_raw_parts(slice.as_ptr() as *const MaybeUninit<u8>, slice.len()) }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sink::SliceSink;
+    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+    use crate::sink::VecSink;
+
+    use super::Sink;
+
+    #[test]
+    fn test_sink_slice() {
+        let mut data = Vec::new();
+        data.resize(5, 0);
+        let mut sink = SliceSink::new(&mut data, 1);
+        assert_eq!(sink.pos(), 1);
+        assert_eq!(sink.capacity(), 5);
+        assert_eq!(sink.filled_slice(), &[0]);
+        sink.extend_from_slice(&[1, 2, 3]);
+        assert_eq!(sink.pos(), 4);
+        assert_eq!(sink.filled_slice(), &[0, 1, 2, 3]);
+    }
+
+    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+    #[test]
+    fn test_sink_vec() {
+        let mut data = Vec::with_capacity(5);
+        data.push(255); // not visible to the sink
+        data.push(0);
+        {
+            let mut sink = VecSink::new(&mut data, 1, 1);
+            assert_eq!(sink.pos(), 1);
+            assert_eq!(sink.capacity(), 4);
+            assert_eq!(sink.filled_slice(), &[0]);
+            sink.extend_from_slice(&[1, 2, 3]);
+            assert_eq!(sink.pos(), 4);
+            assert_eq!(sink.filled_slice(), &[0, 1, 2, 3]);
+        }
+        assert_eq!(data.as_slice(), &[255, 0, 1, 2, 3]);
+    }
+}


### PR DESCRIPTION
In order to safe guard against UB (Undefined Behavior) and safety issues
(exposing uninitialized data) the Sink abstraction is expanded to handle
uninitialized data safely.

Sink changes
* Move Sink abstraction and related bits to its own module.
* Sink safety invariant is that it never exposes uninitialized data.
* Add additional methods to Sink (eg. extend_from_within) that can
safely operate over possibly uninitialized byte slices internally.

New VecSink
* Add VecSink which can be used to create Sinks over possibly
uninitialized Vec data.
* On drop VecSink will adjust the backing Vec length to cover the then
initialized bytes.

Unsafe Compression changes
* `write_u*` functions now use `core::ptr::write` so they can safely
operate on uninitialized data.

Safe compression changes
* Safe wild copies now use `Sink::extend_from_slice_wild` so they can
safely operate on uninitialized bytes.

Safe Decompression changes
* The previous 16 byte wild copy in the slow path didn't play well with
the new Sink as it could expose uninitialized bytes temporarily (which
now panics). It was replaced with fast-paths + fallback which performs
equally or better (eg. 66KB Json dataset).

Unsafe FrameDecoder changes
* Similar to the safe FrameDecoder, decoding a block is now required to
initialize the byte buffer passed to the underlying `Read::read` method.
This will be improved when `Read::read_buf` is stabilized.

Fixes #19