### PR TITLE
It's not an error to pass a buffer larger than the decompressed data.

### DIFF
--- a/src/block/decompress.rs
+++ b/src/block/decompress.rs
@@ -450,12 +450,7 @@ pub fn decompress(input: &[u8], uncompressed_size: usize) -> Result<Vec<u8>, Dec
     let mut vec: Vec<u8> = Vec::with_capacity(uncompressed_size);
     let decomp_len =
         decompress_internal::<_, false>(input, &mut VecSink::new(&mut vec, 0, 0), b"")?;
-    if decomp_len != uncompressed_size {
-        return Err(DecompressError::UncompressedSizeDiffers {
-            expected: uncompressed_size,
-            actual: decomp_len,
-        });
-    }
+    vec.truncate(decomp_len);
     Ok(vec)
 }
 
@@ -481,12 +476,7 @@ pub fn decompress_with_dict(
     let mut vec: Vec<u8> = Vec::with_capacity(uncompressed_size);
     let decomp_len =
         decompress_internal::<_, true>(input, &mut VecSink::new(&mut vec, 0, 0), ext_dict)?;
-    if decomp_len != uncompressed_size {
-        return Err(DecompressError::UncompressedSizeDiffers {
-            expected: uncompressed_size,
-            actual: decomp_len,
-        });
-    }
+    vec.truncate(decomp_len);
     Ok(vec)
 }
 

--- a/src/block/decompress_safe.rs
+++ b/src/block/decompress_safe.rs
@@ -324,17 +324,12 @@ pub fn decompress_size_prepended(input: &[u8]) -> Result<Vec<u8>, DecompressErro
 
 /// Decompress all bytes of `input` into a new vec.
 #[inline]
-pub fn decompress(input: &[u8], uncompressed_size: usize) -> Result<Vec<u8>, DecompressError> {
-    let mut decompressed: Vec<u8> = Vec::with_capacity(uncompressed_size);
-    decompressed.resize(uncompressed_size, 0);
+pub fn decompress(input: &[u8], max_uncompressed_size: usize) -> Result<Vec<u8>, DecompressError> {
+    let mut decompressed: Vec<u8> = Vec::with_capacity(max_uncompressed_size);
+    decompressed.resize(max_uncompressed_size, 0);
     let decomp_len =
         decompress_internal::<_, false>(input, &mut SliceSink::new(&mut decompressed, 0), b"")?;
-    if decomp_len != uncompressed_size {
-        return Err(DecompressError::UncompressedSizeDiffers {
-            expected: uncompressed_size,
-            actual: decomp_len,
-        });
-    }
+    decompressed.truncate(decomp_len);
     Ok(decompressed)
 }
 
@@ -353,19 +348,14 @@ pub fn decompress_size_prepended_with_dict(
 #[inline]
 pub fn decompress_with_dict(
     input: &[u8],
-    uncompressed_size: usize,
+    max_uncompressed_size: usize,
     ext_dict: &[u8],
 ) -> Result<Vec<u8>, DecompressError> {
-    let mut decompressed: Vec<u8> = Vec::with_capacity(uncompressed_size);
-    decompressed.resize(uncompressed_size, 0);
+    let mut decompressed: Vec<u8> = Vec::with_capacity(max_uncompressed_size);
+    decompressed.resize(max_uncompressed_size, 0);
     let decomp_len =
         decompress_internal::<_, true>(input, &mut SliceSink::new(&mut decompressed, 0), ext_dict)?;
-    if decomp_len != uncompressed_size {
-        return Err(DecompressError::UncompressedSizeDiffers {
-            expected: uncompressed_size,
-            actual: decomp_len,
-        });
-    }
+    decompressed.truncate(decomp_len);
     Ok(decompressed)
 }
 

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -85,10 +85,6 @@ pub enum DecompressError {
         expected: usize,
         actual: usize,
     },
-    UncompressedSizeDiffers {
-        expected: usize,
-        actual: usize,
-    },
     /// Literal is out of bounds of the input
     LiteralOutOfBounds,
     /// Expected another byte, but none found.
@@ -121,13 +117,6 @@ impl fmt::Display for DecompressError {
             }
             DecompressError::OffsetOutOfBounds => {
                 f.write_str("the offset to copy is not contained in the decompressed buffer")
-            }
-            DecompressError::UncompressedSizeDiffers { actual, expected } => {
-                write!(
-                    f,
-                    "the expected decompressed size differs, actual {}, expected {}",
-                    actual, expected
-                )
             }
         }
     }


### PR DESCRIPTION
As [per the reference implementation](https://github.com/lz4/lz4/blob/163db1675c0cb5c4e35266e1c1f73e119227ad30/lib/lz4.h#L152) of LZ4_decompress_safe:
> the size of destination buffer (which must be already allocated), presumed **an upper bound** of decompressed size

I think this mistake originates from [a misleading comment on lzzzz](https://github.com/picoHz/lzzzz/blob/master/src/lz4/block/mod.rs#L97) which seems to indicate that the buffer must be exactly the size of the decompressed data. However neither those bindings nor the underlying library make that assertion.

This PR is a breaking change since I removed the now unused `UncompressedSizeDiffers` variant from the `DecompressError` enum.