### PR TITLE
Avoid dependency on twox-hash unless "frame" feature set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ default = ["std", "safe-encode", "safe-decode", "frame"]
 safe-decode = []
 safe-encode = []
 checked-decode = []
-frame = ["std"]
+frame = ["std", "dep:twox-hash"]
 std = []
 
 [dependencies]
-twox-hash = { version = "1.6.2", default-features = false }
+twox-hash = { version = "1.6.2", default-features = false, optional = true }
 
 [profile.bench]
 codegen-units = 1


### PR DESCRIPTION
`twox-hash` is only used by the `frame` module, which is only compiled when the `"frame"` feature is set. This change makes `lz4_flex` a zero-dependency library unless the `"frame"` feature is used.