### PR TITLE
test

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,9 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
-        run: rustup toolchain install nightly --component llvm-tools-preview
-      - name: Install cargo-llvm-cov
-        run: curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/latest/download/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
+        run: rustup toolchain install stable
+      - name: Install llvm
+        run: rustup component add llvm-tools-preview --toolchain stable-x86_64-unknown-linux-gnu
+      - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage normal run
         run: cargo llvm-cov --workspace --lcov --output-path lcov1.info
       - name: Generate code coverage all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ default = ["std", "safe-encode", "safe-decode", "frame"]
 safe-decode = []
 safe-encode = []
 checked-decode = []
-frame = ["std"]
+frame = ["std", "dep:twox-hash"]
 std = []
 
 [dependencies]
-twox-hash = { version = "1.6.2", default-features = false }
+twox-hash = { version = "1.6.2", default-features = false, optional = true }
 
 [profile.bench]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Executed on Core i7-6700 Linux Mint.
 
 [Miri](https://github.com/rust-lang/miri) can be used to find issues related to incorrect unsafe usage:
 
-`MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-disable-stacked-borrows" cargo miri test --no-default-features`
+`MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-disable-stacked-borrows" cargo +nightly miri test --no-default-features --features frame`
 
 ## Fuzzer
 This fuzz target generates corrupted data for the decompressor. Make sure to switch to the checked_decode version in `fuzz/Cargo.toml` before testing this.

--- a/lz4-wasm/Cargo.toml
+++ b/lz4-wasm/Cargo.toml
@@ -2,25 +2,25 @@
 authors = ["Pascal Seitz <pascal.seitz@gmail.com>"]
 description = "High Performance lz4 wasm implementation"
 edition = "2018"
-name = "lz4-wasm"
-version = "0.7.5"
+name = "lz4-wasm-nodejs"
+version = "0.9.2"
 license = "MIT"
 keywords = ["compression", "lz4", "compress", "decompression", "decompress", "wasm"]
 
 [dependencies]
-wasm-bindgen = "0.2.73"
-lz4_flex = { version = "0.7.5", default-features = false, features = ["checked-decode"] }
+wasm-bindgen = "0.2.80"
+lz4_flex = { version = "0.9.2", default-features = false, features = ["checked-decode"] }
 
 [dependencies.console_error_panic_hook]
 optional = true
-version = "0.1.6"
+version = "0.1.7"
 
 [dependencies.wee_alloc]
 optional = true
 version = "0.4.5"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.23"
+wasm-bindgen-test = "0.3.30"
 
 [features]
 default = ["console_error_panic_hook"]

--- a/lz4-wasm/README.md
+++ b/lz4-wasm/README.md
@@ -47,7 +47,6 @@ Due to a long standing bug in wasm-pack 0.9.1, _manually_ add these files to pkg
 
 ```
     "lz4_wasm_bg.wasm.d.ts",
-    "lz4_wasm_bg.js",
 ```
 
 ```


### PR DESCRIPTION
- bump versions
- fix coverage
- Avoid dependency on twox-hash unless "frame" feature set
- update miri command
