### PR TITLE
Guard against usize overflows/underflows and raw pointer undefined behavior

### DIFF
--- a/benches/crit_bench.rs
+++ b/benches/crit_bench.rs
@@ -152,7 +152,8 @@ fn bench_block_compression_throughput(c: &mut Criterion) {
             |b, i| b.iter(|| lz4_flex::compress(i)),
         );
         // an empty slice that the compiler can't infer the size
-        let empty_vec = std::env::args().nth(1000000)
+        let empty_vec = std::env::args()
+            .nth(1000000)
             .unwrap_or_default()
             .into_bytes();
         group.bench_with_input(
@@ -206,7 +207,8 @@ fn bench_block_decompression_throughput(c: &mut Criterion) {
             |b, i| b.iter(|| lz4_flex::decompress(i, input.len())),
         );
         // an empty slice that the compiler can't infer the size
-        let empty_vec = std::env::args().nth(1000000)
+        let empty_vec = std::env::args()
+            .nth(1000000)
             .unwrap_or_default()
             .into_bytes();
         group.bench_with_input(

--- a/src/block/compress.rs
+++ b/src/block/compress.rs
@@ -177,7 +177,7 @@ fn count_same_bytes(input: &[u8], cur: &mut usize, source: &[u8], candidate: usi
     // compare 4 bytes block
     #[cfg(target_pointer_width = "64")]
     {
-        if *cur + 4 <= input_end {
+        if input_end - *cur >= 4 {
             let diff = read_u32_ptr(unsafe { input.as_ptr().add(*cur) }) ^ read_u32_ptr(source_ptr);
 
             if diff == 0 {
@@ -193,7 +193,7 @@ fn count_same_bytes(input: &[u8], cur: &mut usize, source: &[u8], candidate: usi
     }
 
     // compare 2 bytes block
-    if *cur + 2 <= input_end
+    if input_end - *cur >= 2
         && unsafe { read_u16_ptr(input.as_ptr().add(*cur)) == read_u16_ptr(source_ptr) }
     {
         *cur += 2;
@@ -359,7 +359,7 @@ pub(crate) fn compress_internal<T: HashTable, SINK: Sink, const USE_DICT: bool>(
     }
 
     let output_start_pos = output.pos();
-    if input_pos + LZ4_MIN_LENGTH > input.len() {
+    if input.len() - input_pos < LZ4_MIN_LENGTH {
         handle_last_literals(output, input, input_pos);
         return Ok(output.pos() - output_start_pos);
     }

--- a/src/block/decompress_safe.rs
+++ b/src/block/decompress_safe.rs
@@ -118,7 +118,7 @@ pub(crate) fn decompress_internal<SINK: Sink, const USE_DICT: bool>(
         if does_token_fit(token) && input_pos <= safe_input_pos && output.pos() < safe_output_pos {
             let literal_length = (token >> 4) as usize;
 
-            if input_pos + literal_length > input.len() {
+            if literal_length > input.len() - input_pos {
                 return Err(DecompressError::LiteralOutOfBounds);
             }
 
@@ -168,11 +168,11 @@ pub(crate) fn decompress_internal<SINK: Sink, const USE_DICT: bool>(
                 literal_length += read_integer(input, &mut input_pos)? as usize;
             }
 
-            if input_pos + literal_length > input.len() {
+            if literal_length > input.len() - input_pos {
                 return Err(DecompressError::LiteralOutOfBounds);
             }
             #[cfg(feature = "checked-decode")]
-            if output.pos() + literal_length > output.capacity() {
+            if literal_length > output.capacity() - output.pos() {
                 return Err(DecompressError::OutputTooSmall {
                     expected: output.pos() + literal_length,
                     actual: output.capacity(),

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -357,7 +357,7 @@ mod tests {
     #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
     use crate::sink::VecSink;
 
-    use super::Sink;
+    use super::{Sink, Vec};
 
     #[test]
     fn test_sink_slice() {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -548,8 +548,7 @@ mod frame {
     fn content_size() {
         let mut frame_info = lz4_flex::frame::FrameInfo::new();
         frame_info.content_size = Some(COMPRESSION1K.len() as u64);
-        let mut compressed =
-            lz4_flex_frame_compress_with(frame_info, COMPRESSION1K).unwrap();
+        let mut compressed = lz4_flex_frame_compress_with(frame_info, COMPRESSION1K).unwrap();
 
         // roundtrip
         let uncompressed = lz4_flex_frame_decompress(&compressed).unwrap();
@@ -560,8 +559,7 @@ mod frame {
             // We'll generate a valid FrameInfo and copy it to the test data
             let mut frame_info = lz4_flex::frame::FrameInfo::new();
             frame_info.content_size = Some(3);
-            let dummy_compressed =
-                lz4_flex_frame_compress_with(frame_info, b"123").unwrap();
+            let dummy_compressed = lz4_flex_frame_compress_with(frame_info, b"123").unwrap();
             // `15` (7 + 8) is the size of the header plus the content size in the compressed bytes
             compressed[..15].copy_from_slice(&dummy_compressed[..15]);
         }


### PR DESCRIPTION
The main change is to change patterns like `current_position + something > max_position` to `max_position - current_position < something`, which is overflow safe. Closes #49 