### PR TITLE
Add `into_inner()` to FrameDecoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://github.com/pseitz/lz4_flex"
 repository = "https://github.com/pseitz/lz4_flex"
 readme = "README.md"
 license = "MIT"
-version = "0.9.4"
+version = "0.9.5"
 include = ["src/*.rs", "src/frame/**/*", "src/block/**/*", "README.md"]
 
 [[bench]]

--- a/src/frame/compress.rs
+++ b/src/frame/compress.rs
@@ -151,7 +151,7 @@ impl<W: io::Write> FrameEncoder<W> {
     }
 
     /// Returns the underlying writer _without_ flushing the stream.
-    /// This may lave the output in an unfinished state.
+    /// This may leave the output in an unfinished state.
     pub fn into_inner(self) -> W {
         self.w
     }

--- a/src/frame/decompress.rs
+++ b/src/frame/decompress.rs
@@ -102,6 +102,11 @@ impl<R: io::Read> FrameDecoder<R> {
         &mut self.r
     }
 
+    /// Consumes the FrameDecoder and returns the underlying reader.
+    pub fn into_inner(self) -> R {
+        self.r
+    }
+
     fn read_frame_info(&mut self) -> Result<usize, io::Error> {
         let mut buffer = [0u8; MAX_FRAME_INFO_SIZE];
         match self.r.read(&mut buffer[..MIN_FRAME_INFO_SIZE])? {


### PR DESCRIPTION
This method would be handy to use when only a chunk of a file is lz4-compressed.