### PR TITLE
Add support of decoding legacy frames

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -16,6 +16,7 @@ const COMPRESSION34K: &[u8] = include_bytes!("../benches/compression_34k.txt");
 const COMPRESSION65: &[u8] = include_bytes!("../benches/compression_65k.txt");
 const COMPRESSION66JSON: &[u8] = include_bytes!("../benches/compression_66k_JSON.txt");
 const COMPRESSION10MB: &[u8] = include_bytes!("../benches/dickens.txt");
+const DECOMPRESSION10MB: &[u8] = include_bytes!("../benches/dickens.lz4");
 
 fn lz4_cpp_block_compress(input: &[u8]) -> Result<Vec<u8>, lzzzz::Error> {
     let mut out = Vec::new();
@@ -574,6 +575,12 @@ mod frame {
             }
             r => panic!("{:?}", r),
         }
+    }
+
+    #[test]
+    fn legacy_frame() {
+        let uncompressed = lz4_flex_frame_decompress(DECOMPRESSION10MB).unwrap();
+        assert_eq!(uncompressed, COMPRESSION10MB);
     }
 }
 


### PR DESCRIPTION
Hi @PSeitz ,

While working on an utility [ikconfig](https://github.com/yestyle/extract-ikconfig-rs) extracting Linux kernel images, I chose lz4_flex as a dependency to do lz4 decompression. However, Linux kernel is using [legacy frame](https://github.com/lz4/lz4/blob/dev/doc/lz4_Frame_format.md#legacy-frame) and lz4_flex doesn't support it yet. I added the support in my fork and thinking it'd be good to have it upstream so here's the pull request.

Cheers,
Philip