### PR TITLE
faster duplicate_overlapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+benchmarks/target
 Cargo.lock
 my-prof.profile
 Session.vim

--- a/benches/crit_bench.rs
+++ b/benches/crit_bench.rs
@@ -17,12 +17,12 @@ const COMPRESSION10MB: &[u8] = include_bytes!("dickens.txt");
 const COMPRESSION95K_VERY_GOOD_LOGO: &[u8] = include_bytes!("../logo.jpg");
 
 const ALL: &[&[u8]] = &[
-    //COMPRESSION1K as &[u8],
-    //COMPRESSION34K as &[u8],
-    //COMPRESSION65K as &[u8],
-    //COMPRESSION66K as &[u8],
+    COMPRESSION1K as &[u8],
+    COMPRESSION34K as &[u8],
+    COMPRESSION65K as &[u8],
+    COMPRESSION66K as &[u8],
     COMPRESSION10MB as &[u8],
-    // COMPRESSION95K_VERY_GOOD_LOGO as &[u8],
+    COMPRESSION95K_VERY_GOOD_LOGO as &[u8],
 ];
 
 fn compress_lz4_fear(input: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
improve duplicate_overlapping unsafe version. The compiler generates unfavourable assembly for the simple version.
Now we copy 4 bytes, instead of one in every iteration.
Without that the compiler will unroll/auto-vectorize the copy with a lot of branches.
This is not what we want, as large overlapping copies are not that common.
