### PR TITLE
remove VecSink

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,14 +17,14 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test
-    - name: Run tests --features safe-encode
-      run: cargo test --features safe-encode --verbose
+    - name: Run tests safe-encode
+      run: cargo test --features safe-encode
     - name: Run tests safe-decode
-      run: cargo test --verbose --features safe-decode
-    - name: Run tests no-default-features (no safe-decode)
-      run: cargo test --verbose --no-default-features --features frame
-    - name: Ensure no_std compiles for checked-decode
-      run: cargo build --no-default-features --features checked-decode
+      run: cargo test --features safe-decode
+    - name: Run tests --no-default-features (no safe-decode) with frame
+      run: cargo test --no-default-features --features frame
+    - name: Run tests unsafe with checked-decode and frame
+      run: cargo test --no-default-features --features checked-decode --features frame
     - name: Ensure no_std compiles
       run: cargo build --no-default-features
     - name: Ensure no_std compiles for safe-decode

--- a/benches/crit_bench.rs
+++ b/benches/crit_bench.rs
@@ -161,16 +161,16 @@ fn bench_block_compression_throughput(c: &mut Criterion) {
         //&input,
         //|b, i| b.iter(|| lz4_flex::block::compress_with_dict(i, &empty_vec)),
         //);
-        group.bench_with_input(
-            BenchmarkId::new("lz4_redox_rust", input_bytes),
-            &input,
-            |b, i| b.iter(|| lz4_compress::compress(i)),
-        );
-        group.bench_with_input(
-            BenchmarkId::new("lz4_fear_rust", input_bytes),
-            &input,
-            |b, i| b.iter(|| compress_lz4_fear(i)),
-        );
+        //group.bench_with_input(
+        //BenchmarkId::new("lz4_redox_rust", input_bytes),
+        //&input,
+        //|b, i| b.iter(|| lz4_compress::compress(i)),
+        //);
+        //group.bench_with_input(
+        //BenchmarkId::new("lz4_fear_rust", input_bytes),
+        //&input,
+        //|b, i| b.iter(|| compress_lz4_fear(i)),
+        //);
 
         group.bench_with_input(BenchmarkId::new("lz4_cpp", input_bytes), &input, |b, i| {
             b.iter(|| lz4_cpp_block_compress(i))

--- a/examples/compress.rs
+++ b/examples/compress.rs
@@ -1,10 +1,13 @@
 use std::io;
 fn main() {
-    let stdin = io::stdin();
-    let stdout = io::stdout();
-    let mut rdr = stdin.lock();
-    // Wrap the stdout writer in a LZ4 Frame writer.
-    let mut wtr = lz4_flex::frame::FrameEncoder::new(stdout.lock());
-    io::copy(&mut rdr, &mut wtr).expect("I/O operation failed");
-    let _stdout = wtr.finish().unwrap();
+    #[cfg(feature = "frame")]
+    {
+        let stdin = io::stdin();
+        let stdout = io::stdout();
+        let mut rdr = stdin.lock();
+        // Wrap the stdout writer in a LZ4 Frame writer.
+        let mut wtr = lz4_flex::frame::FrameEncoder::new(stdout.lock());
+        io::copy(&mut rdr, &mut wtr).expect("I/O operation failed");
+        let _stdout = wtr.finish().unwrap();
+    }
 }

--- a/examples/decompress.rs
+++ b/examples/decompress.rs
@@ -1,9 +1,12 @@
 use std::io;
 fn main() {
-    let stdin = io::stdin();
-    let stdout = io::stdout();
-    // Wrap the stdin reader in a LZ4 FrameDecoder.
-    let mut rdr = lz4_flex::frame::FrameDecoder::new(stdin.lock());
-    let mut wtr = stdout.lock();
-    io::copy(&mut rdr, &mut wtr).expect("I/O operation failed");
+    #[cfg(feature = "frame")]
+    {
+        let stdin = io::stdin();
+        let stdout = io::stdout();
+        // Wrap the stdin reader in a LZ4 FrameDecoder.
+        let mut rdr = lz4_flex::frame::FrameDecoder::new(stdin.lock());
+        let mut wtr = stdout.lock();
+        io::copy(&mut rdr, &mut wtr).expect("I/O operation failed");
+    }
 }

--- a/src/block/compress.rs
+++ b/src/block/compress.rs
@@ -12,13 +12,19 @@ use crate::block::LZ4_MIN_LENGTH;
 use crate::block::MAX_DISTANCE;
 use crate::block::MFLIMIT;
 use crate::block::MINMATCH;
-use crate::sink::{vec_sink_for_compression, Sink, SliceSink};
+use crate::sink::SliceSink;
 use alloc::vec::Vec;
 
 #[cfg(feature = "safe-encode")]
 use core::convert::TryInto;
 
 use super::{CompressError, WINDOW_SIZE};
+
+pub(crate) fn get_vec_with_size(size: usize) -> Vec<u8> {
+    let mut compressed = Vec::with_capacity(size);
+    compressed.resize(size, 0);
+    compressed
+}
 
 /// Increase step size after 1<<INCREASE_STEPSIZE_BITSHIFT non matches
 const INCREASE_STEPSIZE_BITSHIFT: usize = 5;
@@ -217,7 +223,7 @@ fn count_same_bytes(input: &[u8], cur: &mut usize, source: &[u8], candidate: usi
 /// on. There can be any number of bytes of value "255" following token
 #[inline]
 #[cfg(feature = "safe-encode")]
-fn write_integer(output: &mut impl Sink, mut n: usize) {
+fn write_integer(output: &mut SliceSink, mut n: usize) {
     // Note: Since `n` is usually < 0xFF and writing multiple bytes to the output
     // requires 2 branches of bound check (due to the possibility of add overflows)
     // the simple byte at a time implementation bellow is faster in most cases.
@@ -235,7 +241,7 @@ fn write_integer(output: &mut impl Sink, mut n: usize) {
 /// on. There can be any number of bytes of value "255" following token
 #[inline]
 #[cfg(not(feature = "safe-encode"))]
-fn write_integer(output: &mut impl Sink, mut n: usize) {
+fn write_integer(output: &mut SliceSink, mut n: usize) {
     // Write the 0xFF bytes as long as the integer is higher than said value.
     if n >= 4 * 0xFF {
         // In this unlikelly branch we use a fill instead of a loop,
@@ -260,7 +266,7 @@ fn write_integer(output: &mut impl Sink, mut n: usize) {
 
 /// Handle the last bytes from the input as literals
 #[cold]
-fn handle_last_literals(output: &mut impl Sink, input: &[u8], start: usize) {
+fn handle_last_literals(output: &mut SliceSink, input: &[u8], start: usize) {
     let lit_len = input.len() - start;
 
     let token = token_from_literal(lit_len);
@@ -341,10 +347,10 @@ fn backtrack_match(
 // Intentionally avoid inlining.
 // Empirical tests revealed it to be rarely better but often significantly detrimental.
 #[inline(never)]
-pub(crate) fn compress_internal<T: HashTable, SINK: Sink, const USE_DICT: bool>(
+pub(crate) fn compress_internal<T: HashTable, const USE_DICT: bool>(
     input: &[u8],
     input_pos: usize,
-    output: &mut SINK,
+    output: &mut SliceSink,
     dict: &mut T,
     ext_dict: &[u8],
     input_stream_offset: usize,
@@ -509,13 +515,13 @@ pub(crate) fn compress_internal<T: HashTable, SINK: Sink, const USE_DICT: bool>(
 
 #[inline]
 #[cfg(feature = "safe-encode")]
-fn push_byte(output: &mut impl Sink, el: u8) {
+fn push_byte(output: &mut SliceSink, el: u8) {
     output.push(el);
 }
 
 #[inline]
 #[cfg(not(feature = "safe-encode"))]
-fn push_byte(output: &mut impl Sink, el: u8) {
+fn push_byte(output: &mut SliceSink, el: u8) {
     unsafe {
         core::ptr::write(output.pos_mut_ptr(), el);
         output.set_pos(output.pos() + 1);
@@ -524,13 +530,13 @@ fn push_byte(output: &mut impl Sink, el: u8) {
 
 #[inline]
 #[cfg(feature = "safe-encode")]
-fn push_u16(output: &mut impl Sink, el: u16) {
+fn push_u16(output: &mut SliceSink, el: u16) {
     output.extend_from_slice(&el.to_le_bytes());
 }
 
 #[inline]
 #[cfg(not(feature = "safe-encode"))]
-fn push_u16(output: &mut impl Sink, el: u16) {
+fn push_u16(output: &mut SliceSink, el: u16) {
     unsafe {
         core::ptr::copy_nonoverlapping(el.to_le_bytes().as_ptr(), output.pos_mut_ptr(), 2);
         output.set_pos(output.pos() + 2);
@@ -539,7 +545,7 @@ fn push_u16(output: &mut impl Sink, el: u16) {
 
 #[inline]
 #[cfg(not(feature = "safe-encode"))]
-fn push_u32(output: &mut impl Sink, el: u32) {
+fn push_u32(output: &mut SliceSink, el: u32) {
     unsafe {
         core::ptr::copy_nonoverlapping(el.to_le_bytes().as_ptr(), output.pos_mut_ptr(), 4);
         output.set_pos(output.pos() + 4);
@@ -548,7 +554,7 @@ fn push_u32(output: &mut impl Sink, el: u32) {
 
 #[inline(always)] // (always) necessary otherwise compiler fails to inline it
 #[cfg(feature = "safe-encode")]
-fn copy_literals_wild(output: &mut impl Sink, input: &[u8], input_start: usize, len: usize) {
+fn copy_literals_wild(output: &mut SliceSink, input: &[u8], input_start: usize, len: usize) {
     match len {
         0..=8 => output.extend_from_slice_wild(&input[input_start..input_start + 8], len),
         9..=16 => output.extend_from_slice_wild(&input[input_start..input_start + 16], len),
@@ -559,7 +565,7 @@ fn copy_literals_wild(output: &mut impl Sink, input: &[u8], input_start: usize, 
 
 #[inline]
 #[cfg(not(feature = "safe-encode"))]
-fn copy_literals_wild(output: &mut impl Sink, input: &[u8], input_start: usize, len: usize) {
+fn copy_literals_wild(output: &mut SliceSink, input: &[u8], input_start: usize, len: usize) {
     debug_assert!(input_start + len / 8 * 8 + ((len % 8) != 0) as usize * 8 <= input.len());
     debug_assert!(output.pos() + len / 8 * 8 + ((len % 8) != 0) as usize * 8 <= output.capacity());
     unsafe {
@@ -580,18 +586,18 @@ fn copy_literals_wild(output: &mut impl Sink, input: &[u8], input_start: usize, 
 #[inline]
 pub(crate) fn compress_into_sink(
     input: &[u8],
-    output: &mut impl Sink,
+    output: &mut SliceSink,
 ) -> Result<usize, CompressError> {
     let (dict_size, dict_bitshift) = get_table_size(input.len());
     if input.len() < u16::MAX as usize {
         let mut dict = HashTableU16::new(dict_size, dict_bitshift);
-        compress_internal::<_, _, false>(input, 0, output, &mut dict, b"", 0)
+        compress_internal::<_, false>(input, 0, output, &mut dict, b"", 0)
     } else if input.len() < u32::MAX as usize {
         let mut dict = HashTableU32::new(dict_size, dict_bitshift);
-        compress_internal::<_, _, false>(input, 0, output, &mut dict, b"", 0)
+        compress_internal::<_, false>(input, 0, output, &mut dict, b"", 0)
     } else {
         let mut dict = HashTableUsize::new(dict_size, dict_bitshift);
-        compress_internal::<_, _, false>(input, 0, output, &mut dict, b"", 0)
+        compress_internal::<_, false>(input, 0, output, &mut dict, b"", 0)
     }
 }
 
@@ -599,22 +605,22 @@ pub(crate) fn compress_into_sink(
 #[inline]
 pub(crate) fn compress_into_sink_with_dict(
     input: &[u8],
-    output: &mut impl Sink,
+    output: &mut SliceSink,
     mut dict_data: &[u8],
 ) -> Result<usize, CompressError> {
     let (dict_size, dict_bitshift) = get_table_size(input.len());
     if dict_data.len() + input.len() < u16::MAX as usize {
         let mut dict = HashTableU16::new(dict_size, dict_bitshift);
         init_dict(&mut dict, &mut dict_data);
-        compress_internal::<_, _, true>(input, 0, output, &mut dict, dict_data, dict_data.len())
+        compress_internal::<_, true>(input, 0, output, &mut dict, dict_data, dict_data.len())
     } else if dict_data.len() + input.len() < u32::MAX as usize {
         let mut dict = HashTableU32::new(dict_size, dict_bitshift);
         init_dict(&mut dict, &mut dict_data);
-        compress_internal::<_, _, true>(input, 0, output, &mut dict, dict_data, dict_data.len())
+        compress_internal::<_, true>(input, 0, output, &mut dict, dict_data, dict_data.len())
     } else {
         let mut dict = HashTableUsize::new(dict_size, dict_bitshift);
         init_dict(&mut dict, &mut dict_data);
-        compress_internal::<_, _, true>(input, 0, output, &mut dict, dict_data, dict_data.len())
+        compress_internal::<_, true>(input, 0, output, &mut dict, dict_data, dict_data.len())
     }
 }
 
@@ -671,13 +677,10 @@ pub fn compress_into_with_dict(
 #[inline]
 pub fn compress_prepend_size(input: &[u8]) -> Vec<u8> {
     let max_compressed_size = get_maximum_output_size(input.len());
-    let mut compressed = Vec::with_capacity(4 + max_compressed_size);
-    compressed.extend_from_slice(&(input.len() as u32).to_le_bytes());
-    let compressed_len = compress_into_sink(
-        input,
-        &mut vec_sink_for_compression(&mut compressed, 4, 0, max_compressed_size),
-    )
-    .unwrap();
+    let mut compressed = get_vec_with_size(4 + max_compressed_size);
+    compressed[..4].copy_from_slice(&(input.len() as u32).to_le_bytes());
+    let compressed_len = compress_into(input, &mut compressed[4..]).unwrap();
+
     compressed.truncate(4 + compressed_len);
     compressed
 }
@@ -686,12 +689,8 @@ pub fn compress_prepend_size(input: &[u8]) -> Vec<u8> {
 #[inline]
 pub fn compress(input: &[u8]) -> Vec<u8> {
     let max_compressed_size = get_maximum_output_size(input.len());
-    let mut compressed = Vec::with_capacity(max_compressed_size);
-    let compressed_len = compress_into_sink(
-        input,
-        &mut vec_sink_for_compression(&mut compressed, 0, 0, max_compressed_size),
-    )
-    .unwrap();
+    let mut compressed = get_vec_with_size(max_compressed_size);
+    let compressed_len = compress_into(input, &mut compressed[..]).unwrap();
     compressed.truncate(compressed_len);
     compressed
 }
@@ -700,13 +699,8 @@ pub fn compress(input: &[u8]) -> Vec<u8> {
 #[inline]
 pub fn compress_with_dict(input: &[u8], ext_dict: &[u8]) -> Vec<u8> {
     let max_compressed_size = get_maximum_output_size(input.len());
-    let mut compressed = Vec::with_capacity(max_compressed_size);
-    let compressed_len = compress_into_sink_with_dict(
-        input,
-        &mut vec_sink_for_compression(&mut compressed, 0, 0, max_compressed_size),
-        ext_dict,
-    )
-    .unwrap();
+    let mut compressed = get_vec_with_size(max_compressed_size);
+    let compressed_len = compress_into_with_dict(input, &mut compressed[..], ext_dict).unwrap();
     compressed.truncate(compressed_len);
     compressed
 }
@@ -716,14 +710,11 @@ pub fn compress_with_dict(input: &[u8], ext_dict: &[u8]) -> Vec<u8> {
 #[inline]
 pub fn compress_prepend_size_with_dict(input: &[u8], ext_dict: &[u8]) -> Vec<u8> {
     let max_compressed_size = get_maximum_output_size(input.len());
-    let mut compressed = Vec::with_capacity(4 + max_compressed_size);
-    compressed.extend_from_slice(&(input.len() as u32).to_le_bytes());
-    let compressed_len = compress_into_sink_with_dict(
-        input,
-        &mut vec_sink_for_compression(&mut compressed, 4, 0, max_compressed_size),
-        ext_dict,
-    )
-    .unwrap();
+
+    let mut compressed = get_vec_with_size(4 + max_compressed_size);
+    compressed[..4].copy_from_slice(&(input.len() as u32).to_le_bytes());
+    let compressed_len = compress_into_with_dict(input, &mut compressed[4..], ext_dict).unwrap();
+
     compressed.truncate(4 + compressed_len);
     compressed
 }
@@ -888,7 +879,7 @@ mod tests {
         uncompressed[..output_start].copy_from_slice(&dict[dict_cutoff..]);
         let uncomp_len = {
             let mut sink = SliceSink::new(&mut uncompressed[..], output_start);
-            crate::block::decompress::decompress_internal::<_, true>(
+            crate::block::decompress::decompress_internal::<true>(
                 &compressed,
                 &mut sink,
                 &dict[..dict_cutoff],

--- a/src/frame/compress.rs
+++ b/src/frame/compress.rs
@@ -239,7 +239,7 @@ impl<W: io::Write> FrameEncoder<W> {
 
         let compress_result = if self.ext_dict_len != 0 {
             debug_assert_eq!(self.frame_info.block_mode, BlockMode::Linked);
-            compress_internal::<_, _, true>(
+            compress_internal::<_, true>(
                 input,
                 self.src_start,
                 &mut vec_sink_for_compression(&mut self.dst, 0, 0, dst_required_size),
@@ -248,7 +248,7 @@ impl<W: io::Write> FrameEncoder<W> {
                 self.src_stream_offset,
             )
         } else {
-            compress_internal::<_, _, false>(
+            compress_internal::<_, false>(
                 input,
                 self.src_start,
                 &mut vec_sink_for_compression(&mut self.dst, 0, 0, dst_required_size),

--- a/src/frame/decompress.rs
+++ b/src/frame/decompress.rs
@@ -290,7 +290,7 @@ impl<R: io::Read> FrameDecoder<R> {
                     let ext_dict = &tail[..self.ext_dict_len];
 
                     debug_assert!(head.len() - self.dst_start >= max_block_size);
-                    crate::block::decompress::decompress_internal::<_, true>(
+                    crate::block::decompress::decompress_internal::<true>(
                         &self.src[..len],
                         &mut SliceSink::new(head, self.dst_start),
                         ext_dict,
@@ -298,7 +298,7 @@ impl<R: io::Read> FrameDecoder<R> {
                 } else {
                     // Independent blocks OR linked blocks with only prefix data
                     debug_assert!(self.dst.capacity() - self.dst_start >= max_block_size);
-                    crate::block::decompress::decompress_internal::<_, false>(
+                    crate::block::decompress::decompress_internal::<false>(
                         &self.src[..len],
                         &mut vec_sink_for_decompression(
                             &mut self.dst,
@@ -444,7 +444,6 @@ impl<R: fmt::Debug + io::Read> fmt::Debug for FrameDecoder<R> {
 }
 
 /// Similar to `v.get_mut(start..end) but will adjust the len if needed.
-/// Panics if there's not enough capacity.
 #[inline]
 fn vec_resize_and_get_mut(v: &mut Vec<u8>, start: usize, end: usize) -> &mut [u8] {
     if end > v.len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@
 //! For no_std support only the [`block format`](block/index.html) is supported.
 //!
 //!
-
+#![deny(warnings)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg_attr(test, macro_use)]

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,6 +1,7 @@
+#[cfg(any(feature = "frame"))]
 use alloc::vec::Vec;
-#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
-use core::mem::MaybeUninit;
+//#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+//use core::mem::MaybeUninit;
 
 /// Returns a Sink implementation appropriate for outputing up to `required_capacity`
 /// bytes at `vec[offset..offset+required_capacity]`.
@@ -8,19 +9,13 @@ use core::mem::MaybeUninit;
 /// when the `safe-decode` feature is enabled, or `VecSink` otherwise.
 /// The argument `pos` defines the initial output position in the Sink.
 #[inline]
+#[cfg(any(feature = "frame"))]
 pub fn vec_sink_for_compression(
     vec: &mut Vec<u8>,
     offset: usize,
     pos: usize,
     required_capacity: usize,
-) -> impl Sink + '_ {
-    #[cfg(not(feature = "safe-encode"))]
-    return {
-        assert!(vec.capacity() >= offset + required_capacity);
-        VecSink::new(vec, offset, pos)
-    };
-
-    #[cfg(feature = "safe-encode")]
+) -> SliceSink {
     return {
         vec.resize(offset + required_capacity, 0);
         SliceSink::new(&mut vec[offset..], pos)
@@ -39,21 +34,15 @@ pub fn vec_sink_for_decompression(
     offset: usize,
     pos: usize,
     required_capacity: usize,
-) -> impl Sink + '_ {
-    #[cfg(not(feature = "safe-decode"))]
-    return {
-        assert!(vec.capacity() >= offset + required_capacity);
-        crate::sink::VecSink::new(vec, offset, pos)
-    };
-
-    #[cfg(feature = "safe-decode")]
+) -> SliceSink {
     return {
         vec.resize(offset + required_capacity, 0);
         SliceSink::new(&mut vec[offset..], pos)
     };
 }
 
-/// Sink is used as target to de/compress data into a preallocated and possibly uninitialized memory
+/// SliceSink is used as target to de/compress data into a preallocated and possibly uninitialized
+/// `&[u8]`
 /// space.
 ///
 /// # Handling of Capacity
@@ -61,78 +50,6 @@ pub fn vec_sink_for_decompression(
 ///
 /// # Invariants
 ///   - Bytes `[..pos()]` are always initialized.
-pub trait Sink {
-    /// The bytes that are considered filled.
-    fn filled_slice(&self) -> &[u8];
-
-    /// The current position (aka. len) of the the Sink.
-    fn pos(&self) -> usize;
-
-    /// The total capacity of the Sink.
-    fn capacity(&self) -> usize;
-
-    /// Forces the length of the vector to `new_pos`.
-    /// The caller is responsible for ensuring all bytes up to `new_pos` are properly initialized.
-    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
-    unsafe fn set_pos(&mut self, new_pos: usize);
-
-    /// Returns a raw ptr to the first byte of the Sink. Analogous to `[0..].as_ptr()`.
-    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
-    unsafe fn base_mut_ptr(&mut self) -> *mut u8;
-
-    /// Returns a raw ptr to the first unfilled byte of the Sink. Analogous to `[pos..].as_ptr()`.
-    #[inline]
-    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
-    unsafe fn pos_mut_ptr(&mut self) -> *mut u8 {
-        self.base_mut_ptr().add(self.pos()) as *mut u8
-    }
-
-    /// Pushes a byte to the end of the Sink.
-    #[inline]
-    fn push(&mut self, byte: u8) {
-        self.extend_from_slice(&[byte])
-    }
-
-    /// Pushes `len` elements of `byte` to the end of the Sink.
-    fn extend_with_fill(&mut self, byte: u8, len: usize);
-
-    /// Extends the Sink with `data` but only advances the sink by `copy_len`.
-    /// # Panics
-    /// Panics if `copy_len` > `data.len()`
-    fn extend_from_slice_wild(&mut self, data: &[u8], copy_len: usize);
-
-    /// Extends the Sink with `data`.
-    #[inline]
-    fn extend_from_slice(&mut self, data: &[u8]) {
-        self.extend_from_slice_wild(data, data.len())
-    }
-
-    /// Copies `wild_len` bytes starting from `start` to the end of the Sink.
-    /// The position of the Sink is increased by `copy_len` NOT `wild_len`;
-    /// # Panics
-    /// Panics if `start + copy_len` > `pos`.
-    /// Panics if `copy_len` > `wild_len`.
-    fn extend_from_within_wild(&mut self, start: usize, wild_len: usize, copy_len: usize);
-
-    /// Copies `len` bytes starting from `start` to the end of the Sink.
-    /// # Panics
-    /// Panics if `start` >= `pos`.
-    #[inline]
-    fn extend_from_within(&mut self, start: usize, len: usize) {
-        self.extend_from_within_wild(start, len, len)
-    }
-
-    /// Copies `len` bytes starting from `start` to the end of the Sink.
-    /// Contrary to `extend_from_within`, the copy output can overlap with
-    /// the copy source bytes.
-    /// In addition, a copy with `start` == `pos` is valid and will
-    /// fill the sink `len` zero bytes.
-    /// # Panics
-    /// Panics if `start` > `pos`.
-    fn extend_from_within_overlapping(&mut self, start: usize, len: usize);
-}
-
-/// A Sink baked by a &[u8]
 pub struct SliceSink<'a> {
     /// The working slice, which may contain uninitialized bytes
     output: &'a mut [u8],
@@ -153,50 +70,76 @@ impl<'a> SliceSink<'a> {
     }
 }
 
-impl<'a> Sink for SliceSink<'a> {
+impl<'a> SliceSink<'a> {
+    /// Returns a raw ptr to the first unfilled byte of the Sink. Analogous to `[pos..].as_ptr()`.
+    #[inline]
     #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
-    unsafe fn base_mut_ptr(&mut self) -> *mut u8 {
+    pub(crate) unsafe fn pos_mut_ptr(&mut self) -> *mut u8 {
+        self.base_mut_ptr().add(self.pos()) as *mut u8
+    }
+
+    /// Pushes a byte to the end of the Sink.
+    #[inline]
+    #[cfg(any(feature = "safe-encode"))]
+    pub(crate) fn push(&mut self, byte: u8) {
+        self.output[self.pos] = byte;
+        self.pos += 1;
+    }
+
+    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+    pub(crate) unsafe fn base_mut_ptr(&mut self) -> *mut u8 {
         self.output.as_mut_ptr()
     }
 
     #[inline]
-    fn filled_slice(&self) -> &[u8] {
+    #[cfg(any(feature = "safe-decode"))]
+    pub(crate) fn filled_slice(&self) -> &[u8] {
         &self.output[..self.pos]
     }
 
     #[inline]
-    fn pos(&self) -> usize {
+    pub(crate) fn pos(&self) -> usize {
         self.pos
     }
 
     #[inline]
-    fn capacity(&self) -> usize {
+    pub(crate) fn capacity(&self) -> usize {
         self.output.len()
     }
 
     #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
     #[inline]
-    unsafe fn set_pos(&mut self, new_pos: usize) {
+    pub(crate) unsafe fn set_pos(&mut self, new_pos: usize) {
         debug_assert!(new_pos <= self.capacity());
         self.pos = new_pos;
     }
 
     #[inline]
-    fn extend_with_fill(&mut self, byte: u8, len: usize) {
+    #[cfg(any(feature = "safe-decode"))]
+    pub(crate) fn extend_with_fill(&mut self, byte: u8, len: usize) {
         self.output[self.pos..self.pos + len].fill(byte);
         self.pos += len;
     }
 
+    /// Extends the Sink with `data`.
     #[inline]
-    fn extend_from_slice_wild(&mut self, data: &[u8], copy_len: usize) {
+    pub(crate) fn extend_from_slice(&mut self, data: &[u8]) {
+        self.extend_from_slice_wild(data, data.len())
+    }
+
+    #[inline]
+    pub(crate) fn extend_from_slice_wild(&mut self, data: &[u8], copy_len: usize) {
         assert!(copy_len <= data.len());
         self.output[self.pos..self.pos + data.len()].copy_from_slice(data);
         self.pos += copy_len;
     }
 
+    /// Copies `len` bytes starting from `start` to the end of the Sink.
+    /// # Panics
+    /// Panics if `start` >= `pos`.
     #[inline]
-    fn extend_from_within_wild(&mut self, start: usize, wild_len: usize, copy_len: usize) {
-        // Safety checks so that set_pos later don't expose uninitialized data
+    #[cfg(any(feature = "safe-decode"))]
+    pub(crate) fn extend_from_within(&mut self, start: usize, wild_len: usize, copy_len: usize) {
         assert!(copy_len <= wild_len);
         assert!(start + copy_len <= self.pos);
         self.output.copy_within(start..start + wild_len, self.pos);
@@ -204,7 +147,8 @@ impl<'a> Sink for SliceSink<'a> {
     }
 
     #[inline]
-    fn extend_from_within_overlapping(&mut self, start: usize, len: usize) {
+    #[cfg(any(feature = "safe-decode"))]
+    pub(crate) fn extend_from_within_overlapping(&mut self, start: usize, len: usize) {
         // Sink safety invariant guarantees that the first `pos` items are always initialized.
         assert!(start <= self.pos);
         let offset = self.pos - start;
@@ -217,151 +161,14 @@ impl<'a> Sink for SliceSink<'a> {
     }
 }
 
-#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
-/// A sink backed by a Vec<u8>
-///
-/// Due to the intricacies of uninitialized memory in Rust this
-/// implementation requires using unsafe code even though it is
-/// fully bounds checked and never exposes uninitialized bytes.
-pub struct VecSink<'a> {
-    /// The backing vec
-    output: &'a mut Vec<u8>,
-    /// The output base ptr, a valid pointer within `output` data
-    output_ptr: *mut u8,
-    /// Number of bytes written after `output_ptr`
-    pos: usize,
-    /// Number of bytes available after `output_ptr`
-    capacity: usize,
-}
-
-#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
-impl<'a> VecSink<'a> {
-    /// Creates a `Sink` backed by the Vec bytes at `vec[offset..vec.capacity()]`.
-    /// `pos` defines the initial output position (counted from `offset`) in the Sink.
-    /// Note that the bytes at `vec[output.len()..]` are actually uninitialized and will
-    /// not be readable until written.
-    /// When the `Sink` is dropped the Vec len will be adjusted to `offset` + `Sink.pos`.
-    /// # Panics
-    /// Panics if `pos` is out of bounds.
-    #[inline]
-    pub fn new(output: &'a mut Vec<u8>, offset: usize, pos: usize) -> VecSink<'a> {
-        // The truncation also works as bounds checking for offset and pos.
-        output.truncate(offset + pos);
-        VecSink {
-            capacity: output.capacity() - offset,
-            output_ptr: unsafe { output.as_mut_ptr().add(offset) },
-            output,
-            pos,
-        }
-    }
-}
-#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
-impl<'a> VecSink<'a> {
-    #[inline]
-    fn buffer_mut(&mut self) -> &mut [MaybeUninit<u8>] {
-        // SAFETY: VecSink output_ptr points to at least capacity bytes in length
-        unsafe {
-            core::slice::from_raw_parts_mut(self.output_ptr as *mut MaybeUninit<u8>, self.capacity)
-        }
-    }
-}
-
-#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
-impl<'a> Sink for VecSink<'a> {
-    unsafe fn base_mut_ptr(&mut self) -> *mut u8 {
-        self.output_ptr
-    }
-
-    #[inline]
-    fn filled_slice(&self) -> &[u8] {
-        // SAFETY: Sink safety invariant is that all bytes up to pos are initialized.
-        debug_assert!(self.pos <= self.capacity);
-        unsafe { core::slice::from_raw_parts(self.output_ptr, self.pos) }
-    }
-
-    #[inline]
-    fn pos(&self) -> usize {
-        self.pos
-    }
-
-    #[inline]
-    fn capacity(&self) -> usize {
-        self.capacity
-    }
-
-    #[inline]
-    unsafe fn set_pos(&mut self, new_pos: usize) {
-        self.pos = new_pos
-    }
-
-    #[inline]
-    fn extend_with_fill(&mut self, byte: u8, len: usize) {
-        let pos = self.pos;
-        self.buffer_mut()[pos..pos + len].fill(MaybeUninit::new(byte));
-        self.pos += len;
-    }
-
-    #[inline]
-    fn extend_from_slice_wild(&mut self, data: &[u8], copy_len: usize) {
-        assert!(copy_len <= data.len());
-        let pos = self.pos;
-        self.buffer_mut()[pos..pos + data.len()].copy_from_slice(slice_as_uninit_ref(data));
-        self.pos += copy_len;
-    }
-
-    #[inline]
-    fn extend_from_within_wild(&mut self, start: usize, wild_len: usize, copy_len: usize) {
-        // Safety checks so that pos adjustment doesn't expose uninitialized data
-        assert!(copy_len <= wild_len);
-        assert!(start + copy_len <= self.pos);
-        let pos = self.pos;
-        self.buffer_mut().copy_within(start..start + wild_len, pos);
-        self.pos += copy_len;
-    }
-
-    #[inline]
-    fn extend_from_within_overlapping(&mut self, start: usize, len: usize) {
-        // Sink safety invariant guarantees that the first `pos` items are always initialized.
-        assert!(start <= self.pos);
-        let offset = self.pos - start;
-        let pos = self.pos;
-        let out = &mut self.buffer_mut()[start..pos + len];
-        out[offset] = MaybeUninit::new(0); // ensures that a copy w/ start == pos becomes a zero fill
-        for i in offset..out.len() {
-            out[i] = out[i - offset];
-        }
-        self.pos += len;
-    }
-}
-
-#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
-impl<'a> Drop for VecSink<'a> {
-    #[inline]
-    fn drop(&mut self) {
-        unsafe {
-            let offset = self.output_ptr.offset_from(self.output.as_ptr()) as usize;
-            self.output.set_len(offset + self.pos);
-        }
-    }
-}
-
-#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
-#[inline]
-fn slice_as_uninit_ref(slice: &[u8]) -> &[MaybeUninit<u8>] {
-    // SAFETY: `&[T]` is guaranteed to have the same layout as `&[MaybeUninit<T>]`
-    unsafe { core::slice::from_raw_parts(slice.as_ptr() as *const MaybeUninit<u8>, slice.len()) }
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::sink::SliceSink;
-    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
-    use crate::sink::VecSink;
-
-    use super::{Sink, Vec};
 
     #[test]
+    #[cfg(any(feature = "safe-encode", feature = "safe-decode"))]
     fn test_sink_slice() {
+        use super::Vec;
+        use crate::sink::SliceSink;
         let mut data = Vec::new();
         data.resize(5, 0);
         let mut sink = SliceSink::new(&mut data, 1);
@@ -371,23 +178,5 @@ mod tests {
         sink.extend_from_slice(&[1, 2, 3]);
         assert_eq!(sink.pos(), 4);
         assert_eq!(sink.filled_slice(), &[0, 1, 2, 3]);
-    }
-
-    #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
-    #[test]
-    fn test_sink_vec() {
-        let mut data = Vec::with_capacity(5);
-        data.push(255); // not visible to the sink
-        data.push(0);
-        {
-            let mut sink = VecSink::new(&mut data, 1, 1);
-            assert_eq!(sink.pos(), 1);
-            assert_eq!(sink.capacity(), 4);
-            assert_eq!(sink.filled_slice(), &[0]);
-            sink.extend_from_slice(&[1, 2, 3]);
-            assert_eq!(sink.pos(), 4);
-            assert_eq!(sink.filled_slice(), &[0, 1, 2, 3]);
-        }
-        assert_eq!(data.as_slice(), &[255, 0, 1, 2, 3]);
     }
 }


### PR DESCRIPTION
remove VecSink since it can be fully replaced with a slice
this will reduce code bloat from generics
