### PR TITLE
simplify extend_from_within_overlapping

### DIFF
--- a/src/sink.rs
+++ b/src/sink.rs
@@ -148,16 +148,12 @@ impl<'a> SliceSink<'a> {
 
     #[inline]
     #[cfg(any(feature = "safe-decode"))]
-    pub(crate) fn extend_from_within_overlapping(&mut self, start: usize, len: usize) {
-        // Sink safety invariant guarantees that the first `pos` items are always initialized.
-        assert!(start <= self.pos);
+    pub(crate) fn extend_from_within_overlapping(&mut self, start: usize, num_bytes: usize) {
         let offset = self.pos - start;
-        let out = &mut self.output[start..self.pos + len];
-        out[offset] = 0; // ensures that a copy w/ start == pos becomes a zero fill
-        for i in offset..out.len() {
-            out[i] = out[i - offset];
+        for i in start + offset..start + offset + num_bytes {
+            self.output[i] = self.output[i - offset];
         }
-        self.pos += len;
+        self.pos += num_bytes;
     }
 }
 


### PR DESCRIPTION
extend_from_within_overlapping is used in safe decompression when
overlapping data has been detected. The prev version had unnecessary
assertions/safe guard, since this method is only used in safe code.
Removing the temporary &mut slice also simplified assembly output.

uiCA Code Analyzer

Prev
Tool 	    Skylake	IceLake 	Tiger Lake 	Rocket Lake
uiCA Cycles 28.71 	30.67 		28.71 		27.57

Simplified
Tool 	    Skylake	IceLake 	TigerLake 	Rocket Lake
uiCA Cycles 13.00 	15.00 		13.00 		11.00
