### PR TITLE
Improve safe decompression performance 8-18%

### DIFF
--- a/examples/decompress_block.rs
+++ b/examples/decompress_block.rs
@@ -1,0 +1,7 @@
+fn main() {
+    use lz4_flex::{compress_prepend_size, decompress_size_prepended};
+    let input: &[u8] = b"Hello people, what's up?";
+    let compressed = compress_prepend_size(input);
+    let uncompressed = decompress_size_prepended(&compressed).unwrap();
+    assert_eq!(input, uncompressed);
+}

--- a/src/block/decompress_safe.rs
+++ b/src/block/decompress_safe.rs
@@ -261,10 +261,7 @@ fn duplicate_slice(
     if match_length > offset {
         duplicate_overlapping_slice(output, offset, match_length)?;
     } else {
-        let (start, did_overflow_1) = output.pos().overflowing_sub(offset);
-        if did_overflow_1 {
-            return Err(DecompressError::OffsetOutOfBounds);
-        }
+        let start = output.pos() - offset;
         match match_length {
             0..=32 if output.pos() + 32 <= output.capacity() => {
                 output.extend_from_within(start, 32, match_length)

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -52,9 +52,9 @@ pub fn vec_sink_for_decompression(
 ///   - Bytes `[..pos()]` are always initialized.
 pub struct SliceSink<'a> {
     /// The working slice, which may contain uninitialized bytes
-    output: &'a mut [u8],
+    pub output: &'a mut [u8],
     /// Number of bytes in start of `output` guaranteed to be initialized
-    pos: usize,
+    pub pos: usize,
 }
 
 impl<'a> SliceSink<'a> {
@@ -89,12 +89,6 @@ impl<'a> SliceSink<'a> {
     #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
     pub(crate) unsafe fn base_mut_ptr(&mut self) -> *mut u8 {
         self.output.as_mut_ptr()
-    }
-
-    #[inline]
-    #[cfg(any(feature = "safe-decode"))]
-    pub(crate) fn filled_slice(&self) -> &[u8] {
-        &self.output[..self.pos]
     }
 
     #[inline]
@@ -165,12 +159,8 @@ mod tests {
         use crate::sink::SliceSink;
         let mut data = Vec::new();
         data.resize(5, 0);
-        let mut sink = SliceSink::new(&mut data, 1);
+        let sink = SliceSink::new(&mut data, 1);
         assert_eq!(sink.pos(), 1);
         assert_eq!(sink.capacity(), 5);
-        assert_eq!(sink.filled_slice(), &[0]);
-        sink.extend_from_slice(&[1, 2, 3]);
-        assert_eq!(sink.pos(), 4);
-        assert_eq!(sink.filled_slice(), &[0, 1, 2, 3]);
     }
 }

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -138,16 +138,14 @@ impl<'a> SliceSink<'a> {
     /// # Panics
     /// Panics if `start` >= `pos`.
     #[inline]
-    #[cfg(any(feature = "safe-decode"))]
+    #[cfg(feature = "safe-decode")]
     pub(crate) fn extend_from_within(&mut self, start: usize, wild_len: usize, copy_len: usize) {
-        assert!(copy_len <= wild_len);
-        assert!(start + copy_len <= self.pos);
         self.output.copy_within(start..start + wild_len, self.pos);
         self.pos += copy_len;
     }
 
     #[inline]
-    #[cfg(any(feature = "safe-decode"))]
+    #[cfg(feature = "safe-decode")]
     pub(crate) fn extend_from_within_overlapping(&mut self, start: usize, num_bytes: usize) {
         let offset = self.pos - start;
         for i in start + offset..start + offset + num_bytes {


### PR DESCRIPTION
    Improve safe decompression speed by 8-18%
    
    Reduce multiple slice fetches. every slice access, also nested ones
    ,carries some overhead. In the hot loop a fixed &[u8;16] is fetched to
    operate on. This is purely done to pass that info to the compiler.
    
    Remove error handling that only carries overhead. As we are in safe
    mode we can rely on bounds checks if custom error handling only adds overhead.
    In normal operation no error should occur.
    
    The strategy to identify improvements was by counting the lines of
    assembly. A rough heuristic, but seems effective.
    cargo asm --release --example decompress_block decompress_block::main |
    wc -l

