### PR TITLE
fix: enable initial size check unconditionally

### DIFF
--- a/miri_tests/.gitignore
+++ b/miri_tests/.gitignore
@@ -1,0 +1,6 @@
+/target
+benchmarks/target
+Cargo.lock
+my-prof.profile
+Session.vim
+/benchmarks/bench_files

--- a/miri_tests/Cargo.toml
+++ b/miri_tests/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "miri_tests"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rand = "0.8.5"
+lz4_flex = { path = "..", default-features = false, features=["frame", "checked-decode"] }
+

--- a/miri_tests/README.md
+++ b/miri_tests/README.md
@@ -1,0 +1,3 @@
+# Miri-Tests
+
+This crates purpose to test the lz4_flex crates behavior on corrupted data.

--- a/miri_tests/src/main.rs
+++ b/miri_tests/src/main.rs
@@ -1,0 +1,30 @@
+use std::panic;
+
+use lz4_flex::{block::decompress_size_prepended_with_dict, decompress_size_prepended};
+
+fn main() {
+    println!("Hello, world!");
+
+    for _i in 0..1_000 {
+        println!("Run {_i:?}");
+        let mut data = gen_bytes();
+        let dict = gen_bytes();
+        println!("Loaded Bytes");
+        if data.len() >= 4 {
+            let size = u32::from_le_bytes(data[0..4].try_into().unwrap());
+            let size = size % 16_000;
+            data[0..4].copy_from_slice(size.to_le_bytes().as_ref());
+        }
+        // may panic, that's fine
+        let _result = panic::catch_unwind(|| {
+            let _ = decompress_size_prepended(&data);
+
+            let _ = decompress_size_prepended_with_dict(&data, &dict);
+        });
+    }
+}
+
+fn gen_bytes() -> Vec<u8> {
+    let num_bytes: u8 = rand::random();
+    (0..num_bytes).map(|_| rand::random()).collect()
+}

--- a/src/block/decompress.rs
+++ b/src/block/decompress.rs
@@ -206,12 +206,9 @@ pub(crate) fn decompress_internal<const USE_DICT: bool>(
     output: &mut SliceSink,
     ext_dict: &[u8],
 ) -> Result<usize, DecompressError> {
-    #[cfg(not(feature = "checked-decode"))]
-    {
-        // Prevent segfault for empty input even if checked-decode isn't enabled
-        if input.is_empty() {
-            return Err(DecompressError::ExpectedAnotherByte);
-        }
+    // Prevent segfault for empty input
+    if input.is_empty() {
+        return Err(DecompressError::ExpectedAnotherByte);
     }
 
     let ext_dict = if USE_DICT {


### PR DESCRIPTION
the initial size check in the unsafe decompression was incorrectly disabled for with `checked-decode`
