### PR TITLE
increase unsafe compression speed by 3%

### DIFF
--- a/examples/compress_block.rs
+++ b/examples/compress_block.rs
@@ -1,0 +1,5 @@
+fn main() {
+    use lz4_flex::compress_prepend_size;
+    let input: &[u8] = b"Hello people, what's up?";
+    let _compressed = compress_prepend_size(input);
+}

--- a/src/block/decompress.rs
+++ b/src/block/decompress.rs
@@ -7,7 +7,7 @@ pub(crate) fn get_vec_with_size(size: usize) -> Vec<u8> {
     let mut compressed = Vec::with_capacity(size);
     unsafe {
         // SAFETY: We are using this to avoid having to zero out the memory.
-        // This is safe because we are only going to write to the buffer.
+        // This is safe because we are _only_ going to write to the buffer.
         // This is also safe because we are going to truncate the buffer up
         // to written bytes before returning it. The buffer is wrapped into
         // `SliceSink`, to uphold that invariant.
@@ -272,8 +272,6 @@ pub(crate) fn decompress_internal<const USE_DICT: bool>(
             // that we are far away enough from the end so we can safely copy 16 bytes
             unsafe {
                 core::ptr::copy_nonoverlapping(input_ptr, output_ptr, 16);
-            }
-            unsafe {
                 input_ptr = input_ptr.add(literal_length);
                 output_ptr = output_ptr.add(literal_length);
             }


### PR DESCRIPTION
Remove some code which is used only in a rare edge case to increase
compression speed. When counting the same bytes, the 7 last bytes
of the input are now ignored.

Used tool: cargo asm + llvm-mca shows increased throughput
`cargo asm --release --no-default-features --features checked-decode --example compress_block compress_internal --mca-intel | grep Through`

The same optimization can't be used for the safe version (removing the
cold marked internal function). It produces (not obviously)
worse assembly for some reason. That can be seen via the tool and in the
benchmark.
