### PR TITLE
`FrameInfo` builder

### DIFF
--- a/src/frame/header.rs
+++ b/src/frame/header.rs
@@ -153,7 +153,7 @@ pub struct FrameInfo {
     /// If set, includes a content checksum to verify that the full frame contents have been
     /// decoded correctly.
     pub content_checksum: bool,
-    /// If set, use legacy frame format
+    /// If set, use the legacy frame format
     pub legacy_frame: bool,
 }
 
@@ -162,6 +162,44 @@ impl FrameInfo {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Whether to include the total uncompressed size of data in the frame.
+    pub fn content_size(mut self, content_size: Option<u64>) -> Self {
+        self.content_size = content_size;
+        self
+    }
+
+    /// The maximum uncompressed size of each data block.
+    pub fn block_size(mut self, block_size: BlockSize) -> Self {
+        self.block_size = block_size;
+        self
+    }
+
+    /// The block mode.
+    pub fn block_mode(mut self, block_mode: BlockMode) -> Self {
+        self.block_mode = block_mode;
+        self
+    }
+
+    /// If set, includes a checksum for each data block in the frame.
+    pub fn block_checksums(mut self, block_checksums: bool) -> Self {
+        self.block_checksums = block_checksums;
+        self
+    }
+
+    /// If set, includes a content checksum to verify that the full frame contents have been
+    /// decoded correctly.
+    pub fn content_checksum(mut self, content_checksum: bool) -> Self {
+        self.content_checksum = content_checksum;
+        self
+    }
+
+    /// If set, use the legacy frame format.
+    pub fn legacy_frame(mut self, legacy_frame: bool) -> Self {
+        self.legacy_frame = legacy_frame;
+        self
+    }
+
     pub(crate) fn read_size(input: &[u8]) -> Result<usize, Error> {
         let mut required = MIN_FRAME_INFO_SIZE;
         let magic_num = u32::from_le_bytes(input[0..4].try_into().unwrap());

--- a/src/frame/header.rs
+++ b/src/frame/header.rs
@@ -134,7 +134,7 @@ impl Default for BlockMode {
 // |:----------:| ------ |:----------------:|
 // |  4 bytes   |        |   0 - 4 bytes    |
 //
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 /// The metadata for de/compressing with lz4 frame format.
 pub struct FrameInfo {
     /// If set, includes the total uncompressed size of data in the frame.
@@ -157,24 +157,10 @@ pub struct FrameInfo {
     pub legacy_frame: bool,
 }
 
-impl Default for FrameInfo {
-    fn default() -> Self {
-        FrameInfo::new()
-    }
-}
-
 impl FrameInfo {
     /// Create a new `FrameInfo`.
     pub fn new() -> Self {
-        Self {
-            content_size: None,
-            dict_id: None,
-            block_size: BlockSize::default(),
-            block_mode: BlockMode::default(),
-            block_checksums: false,
-            content_checksum: false,
-            legacy_frame: false,
-        }
+        Self::default()
     }
     pub(crate) fn read_size(input: &[u8]) -> Result<usize, Error> {
         let mut required = MIN_FRAME_INFO_SIZE;


### PR DESCRIPTION
This adds in fluent API style contruction for `FrameInfo`. Now you can do

```rust
let info = FrameInfo::new()
    .block_size(BlockSize::Max1MB)
    .content_checksum(true);
```

IMO it reads better, but it also has the benefit of making it easier to see when the returned `FrameInfo` is unused through avoiding mutability. E.g this wouldn't get picked up as unused

```rust
let mut info = FrameInfo::new();
info.content_checksum = true;
```