### PR TITLE
Don't panic on drop

### DIFF
--- a/src/frame/compress.rs
+++ b/src/frame/compress.rs
@@ -405,7 +405,6 @@ impl<W: io::Write> io::Write for FrameEncoder<W> {
 /// [`finish()`]: FrameEncoder::finish
 /// [`try_finish()`]: FrameEncoder::try_finish
 /// [`auto_finish()`]: FrameEncoder::auto_finish
-/// [`FrameEncoder<W>`]: FrameEncoder
 pub struct AutoFinishEncoder<W: Write> {
     // We wrap this in an option to take it during drop.
     encoder: Option<FrameEncoder<W>>,

--- a/src/frame/compress.rs
+++ b/src/frame/compress.rs
@@ -401,9 +401,7 @@ pub struct AutoFinishEncoder<W: Write> {
 impl<W: io::Write> Drop for AutoFinishEncoder<W> {
     fn drop(&mut self) {
         if let Some(mut encoder) = self.encoder.take() {
-            if let Err(err) = encoder.try_finish() {
-                panic!("Error when flushing frame on drop {:?} ", err);
-            }
+            let _ = encoder.try_finish();
         }
     }
 }

--- a/src/frame/compress.rs
+++ b/src/frame/compress.rs
@@ -30,7 +30,11 @@ use crate::block::WINDOW_SIZE;
 /// writer in a `std::io::BufWriter`.
 ///
 /// To ensure a well formed stream the encoder must be finalized by calling
-/// either `finish` or `try_finish()` methods.
+/// either the [`finish()`], [`try_finish()`], or [`auto_finish()`] methods.
+///
+/// [`finish()`]: Self::finish
+/// [`try_finish()`]: Self::try_finish
+/// [`auto_finish()`]: Self::auto_finish
 ///
 /// # Example 1
 /// Serializing json values into a compressed file.
@@ -112,6 +116,13 @@ impl<W: io::Write> FrameEncoder<W> {
     }
 
     /// Returns a wrapper around `self` that will finish the stream on drop.
+    ///
+    /// # Note
+    /// Errors on drop get silently ignored. If you want to handle errors then use [`finish()`] or
+    /// [`try_finish()`] instead.
+    ///
+    /// [`finish()`]: Self::finish
+    /// [`try_finish()`]: Self::try_finish
     pub fn auto_finish(self) -> AutoFinishEncoder<W> {
         AutoFinishEncoder {
             encoder: Some(self),
@@ -383,12 +394,18 @@ impl<W: io::Write> io::Write for FrameEncoder<W> {
     }
 }
 
-/// A wrapper around an `FrameEncoder<W>` that finishes the stream on drop.
+/// A wrapper around an [`FrameEncoder<W>`] that finishes the stream on drop.
 ///
-/// This can be created by the [`auto_finish()`] method on the [`FrameEncoder`].
+/// This can be created by the [`auto_finish()`] method on the [`FrameEncoder<W>`].
 ///
-/// [`auto_finish()`]: Encoder::auto_finish
-/// [`Encoder`]: Encoder
+/// # Note
+/// Errors on drop get silently ignored. If you want to handle errors then use [`finish()`] or
+/// [`try_finish()`] instead.
+///
+/// [`finish()`]: FrameEncoder::finish
+/// [`try_finish()`]: FrameEncoder::try_finish
+/// [`auto_finish()`]: FrameEncoder::auto_finish
+/// [`FrameEncoder<W>`]: FrameEncoder
 pub struct AutoFinishEncoder<W: Write> {
     // We wrap this in an option to take it during drop.
     encoder: Option<FrameEncoder<W>>,

--- a/src/frame/compress.rs
+++ b/src/frame/compress.rs
@@ -112,10 +112,6 @@ impl<W: io::Write> FrameEncoder<W> {
     }
 
     /// Returns a wrapper around `self` that will finish the stream on drop.
-    ///
-    /// # Panic
-    ///
-    /// Panics on drop if an error happens when finishing the stream.
     pub fn auto_finish(self) -> AutoFinishEncoder<W> {
         AutoFinishEncoder {
             encoder: Some(self),

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -25,7 +25,7 @@ pub(crate) mod compress;
 pub(crate) mod decompress;
 pub(crate) mod header;
 
-pub use compress::FrameEncoder;
+pub use compress::{AutoFinishEncoder, FrameEncoder};
 pub use decompress::FrameDecoder;
 pub use header::{BlockMode, BlockSize, FrameInfo};
 


### PR DESCRIPTION
This makes the `Drop` impl for `AutoFinishEncoder<_>` infallible. Panicking on `drop` is a very easy way to cause a program to abort since drop impls run while unwinding a panic which can cause a panic while already panicking

I tried making `Encoder` automatically call `.try_finish()` on drop, so that `AutoFinishEncoder<_>` wouldn't be needed in the first place, but my implementation probably regressed performance too much for your liking even though running finalization on drop is common (see `zip`, `xz2`, etc). I'll keep toying around with it to see if I can figure out the cause of the only severe regression (`FrameCompress/lz4_flex_rust_(indep|linked)/66675`). It goes with the common technique of wrapping the writer in an `Option<_>`, so that it can be `.take`n by methods like `.into_inner()` while still providing a drop impl