### PR TITLE
Add incantation to display feature in docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ license = "MIT"
 version = "0.10.0"
 include = ["src/*.rs", "src/frame/**/*", "src/block/**/*", "README.md"]
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [[bench]]
 harness = false
 name = "crit_bench"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[allow(unused_imports)]
 #[cfg_attr(test, macro_use)]
@@ -84,6 +85,7 @@ extern crate more_asserts;
 
 pub mod block;
 #[cfg(feature = "frame")]
+#[cfg_attr(docsrs, doc(cfg(feature = "frame")))]
 pub mod frame;
 
 pub use block::{compress, compress_into, compress_prepend_size};


### PR DESCRIPTION
This sets things up so that the `frame` module gets a marker in docs.rs that the `"frame"` feature has to be used. You can see this locally by running

```bash
$ RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --open
```