### PR TITLE
improve unsafe Decompression 0-8%

### DIFF
--- a/src/fastcpy_unsafe.rs
+++ b/src/fastcpy_unsafe.rs
@@ -1,0 +1,165 @@
+//! # FastCpy
+//!
+//! The Rust Compiler calls `memcpy` for slices of unknown length.
+//! This crate provides a faster implementation of `memcpy` for slices up to 32bytes (64bytes with `avx`).
+//! If you know most of you copy operations are not too big you can use `fastcpy` to speed up your program.
+//!
+//! `fastcpy` is designed to contain not too much assembly, so the overhead is low.
+//!
+//! As fall back the standard `memcpy` is called
+//!
+//! ## Double Copy Trick
+//! `fastcpy` employs a double copy trick to copy slices of length 4-32bytes (64bytes with `avx`).
+//! E.g. Slice of length 6 can be copied with two uncoditional copy operations.
+//!
+//! /// [1, 2, 3, 4, 5, 6]
+//! /// [1, 2, 3, 4]
+//! ///       [3, 4, 5, 6]
+//!
+
+#[inline]
+pub fn slice_copy(src: *const u8, dst: *mut u8, num_bytes: usize) {
+    if num_bytes < 4 {
+        short_copy(src, dst, num_bytes);
+        return;
+    }
+
+    if num_bytes < 8 {
+        double_copy_trick::<4>(src, dst, num_bytes);
+        return;
+    }
+
+    if num_bytes <= 16 {
+        double_copy_trick::<8>(src, dst, num_bytes);
+        return;
+    }
+
+    //if num_bytes <= 32 {
+    //double_copy_trick::<16>(src, dst, num_bytes);
+    //return;
+    //}
+
+    // /// The code will use the vmovdqu instruction to copy 32 bytes at a time.
+    //#[cfg(target_feature = "avx")]
+    //{
+    //if num_bytes <= 64 {
+    //double_copy_trick::<32>(src, dst, num_bytes);
+    //return;
+    //}
+    //}
+
+    // For larger sizes we use the default, which calls memcpy
+    // memcpy does some virtual memory tricks to copy large chunks of memory.
+    //
+    // The theory should be that the checks above don't cost much relative to the copy call for
+    // larger copies.
+    // The bounds checks in `copy_from_slice` are elided.
+
+    //unsafe { core::ptr::copy_nonoverlapping(src, dst, num_bytes) }
+    wild_copy_from_src::<16>(src, dst, num_bytes)
+}
+
+// Inline never because otherwise we get a call to memcpy -.-
+#[inline]
+fn wild_copy_from_src<const SIZE: usize>(
+    mut source: *const u8,
+    mut dst: *mut u8,
+    num_bytes: usize,
+) {
+    // Note: if the compiler auto-vectorizes this it'll hurt performance!
+    // It's not the case for 16 bytes stepsize, but for 8 bytes.
+    let l_last = unsafe { source.add(num_bytes - SIZE) };
+    let r_last = unsafe { dst.add(num_bytes - SIZE) };
+    let num_bytes = (num_bytes / SIZE) * SIZE;
+
+    unsafe {
+        let dst_ptr_end = dst.add(num_bytes);
+        loop {
+            core::ptr::copy_nonoverlapping(source, dst, SIZE);
+            source = source.add(SIZE);
+            dst = dst.add(SIZE);
+            if dst >= dst_ptr_end {
+                break;
+            }
+        }
+    }
+
+    unsafe {
+        core::ptr::copy_nonoverlapping(l_last, r_last, SIZE);
+    }
+}
+
+#[inline]
+fn short_copy(src: *const u8, dst: *mut u8, len: usize) {
+    unsafe {
+        *dst = *src;
+    }
+    if len >= 2 {
+        double_copy_trick::<2>(src, dst, len);
+    }
+}
+
+#[inline(always)]
+/// [1, 2, 3, 4, 5, 6]
+/// [1, 2, 3, 4]
+///       [3, 4, 5, 6]
+fn double_copy_trick<const SIZE: usize>(src: *const u8, dst: *mut u8, len: usize) {
+    let l_end = unsafe { src.add(len - SIZE) };
+    let r_end = unsafe { dst.add(len - SIZE) };
+
+    unsafe {
+        core::ptr::copy_nonoverlapping(src, dst, SIZE);
+        core::ptr::copy_nonoverlapping(l_end, r_end, SIZE);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::slice_copy;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn test_fast_short_slice_copy(left: Vec<u8>) {
+            if left.is_empty() {
+                return Ok(());
+            }
+            let mut right = vec![0u8; left.len()];
+            slice_copy(left.as_ptr(), right.as_mut_ptr(), left.len());
+            prop_assert_eq!(&left, &right);
+        }
+    }
+
+    #[test]
+    fn test_fast_short_slice_copy_edge_cases() {
+        for len in 1..(512 * 2) {
+            let left = (0..len).map(|i| i as u8).collect::<Vec<_>>();
+            let mut right = vec![0u8; len];
+            slice_copy(left.as_ptr(), right.as_mut_ptr(), left.len());
+            assert_eq!(left, right);
+        }
+    }
+
+    #[test]
+    fn test_fail2() {
+        let left = vec![
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31, 32,
+        ];
+        let mut right = vec![0u8; left.len()];
+        slice_copy(left.as_ptr(), right.as_mut_ptr(), left.len());
+        assert_eq!(left, right);
+    }
+
+    #[test]
+    fn test_fail() {
+        let left = vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ];
+        let mut right = vec![0u8; left.len()];
+        slice_copy(left.as_ptr(), right.as_mut_ptr(), left.len());
+        assert_eq!(left, right);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,8 @@ pub mod frame;
 
 #[allow(dead_code)]
 mod fastcpy;
+#[allow(dead_code)]
+mod fastcpy_unsafe;
 
 pub use block::{compress, compress_into, compress_prepend_size};
 pub use block::{decompress, decompress_into, decompress_size_prepended};


### PR DESCRIPTION
improve unsafe Decompression by 0-8% by replacing memcpy calls with a custom function

```
BlockDecompress/lz4_flex_rust/725
                        time:   [213.25 ns 213.87 ns 214.67 ns]
                        thrpt:  [3.1454 GiB/s 3.1571 GiB/s 3.1663 GiB/s]
                 change:
                        time:   [-2.6612% -2.2451% -1.7947%] (p = 0.00 < 0.05)
                        thrpt:  [+1.8275% +2.2967% +2.7340%]
                        Performance has improved.
BlockDecompress/lz4_flex_rust/34308
                        time:   [15.369 µs 15.397 µs 15.422 µs]
                        thrpt:  [2.0719 GiB/s 2.0753 GiB/s 2.0790 GiB/s]
                 change:
                        time:   [-1.2694% -0.9057% -0.5299%] (p = 0.00 < 0.05)
                        thrpt:  [+0.5327% +0.9140% +1.2857%]
                        Change within noise threshold.
BlockDecompress/lz4_flex_rust/64723
                        time:   [27.474 µs 27.525 µs 27.577 µs]
                        thrpt:  [2.1858 GiB/s 2.1900 GiB/s 2.1940 GiB/s]
                 change:
                        time:   [-2.7110% -2.4352% -2.1634%] (p = 0.00 < 0.05)
                        thrpt:  [+2.2113% +2.4960% +2.7865%]
                        Performance has improved.
BlockDecompress/lz4_flex_rust/66675
                        time:   [10.224 µs 10.287 µs 10.367 µs]
                        thrpt:  [5.9897 GiB/s 6.0361 GiB/s 6.0738 GiB/s]
                 change:
                        time:   [-10.535% -10.268% -9.9730%] (p = 0.00 < 0.05)
                        thrpt:  [+11.078% +11.443% +11.775%]
                        Performance has improved.
BlockDecompress/lz4_cpp/66675
                        time:   [11.542 µs 11.563 µs 11.590 µs]
                        thrpt:  [5.3577 GiB/s 5.3702 GiB/s 5.3800 GiB/s]
                 change:
                        time:   [-1.9330% -1.3642% -0.8404%] (p = 0.00 < 0.05)
                        thrpt:  [+0.8475% +1.3830% +1.9711%]
                        Change within noise threshold.
BlockDecompress/lz4_flex_rust/9991663
                        time:   [3.6115 ms 3.6234 ms 3.6362 ms]
                        thrpt:  [2.5591 GiB/s 2.5681 GiB/s 2.5766 GiB/s]
                 change:
                        time:   [-0.5029% -0.1070% +0.3170%] (p = 0.62 > 0.05)
                        thrpt:  [-0.3160% +0.1071% +0.5054%]
                        No change in performance detected.
BlockDecompress/lz4_flex_rust/96274
                        time:   [3.2652 µs 3.2939 µs 3.3293 µs]
                        thrpt:  [26.931 GiB/s 27.221 GiB/s 27.460 GiB/s]
                 change:
                        time:   [+28.650% +30.025% +31.445%] (p = 0.00 < 0.05)
                        thrpt:  [-23.922% -23.092% -22.270%]
                        Performance has regressed.
```