### PR TITLE
invert checked-decode to unchecked-decode

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Generate code coverage all-features
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov2.info
       - name: Generate code coverage unsafe w. checked-decode
-        run: cargo llvm-cov --no-default-features --features frame --features checked-decode --workspace --lcov --output-path lcov3.info
+        run: cargo llvm-cov --no-default-features --features frame --workspace --lcov --output-path lcov3.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Run tests --no-default-features with frame, with nightly features
       run: cargo +nightly test --no-default-features --features frame --features nightly
     - name: Run tests unsafe with checked-decode and frame
-      run: cargo test --no-default-features --features checked-decode --features frame
+      run: cargo test --no-default-features --features frame
     - name: Install cargo fuzz
       run: cargo install cargo-fuzz
     - name: Run fuzz tests (safe)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ git = "https://github.com/main--/rust-lz-fear"
 default = ["std", "safe-encode", "safe-decode", "frame"]
 safe-decode = []
 safe-encode = []
-checked-decode = []
+unchecked-decode = [] # Removes some checks for additional performance. Only enable on trusted input!
 frame = ["std", "dep:twox-hash"]
 std = []
 # use nightly compiler features

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Performance:
 lz4_flex = { version = "0.10", default-features = false }
 ```
 
-Warning: If you don't trust your input and your are using the Block format, use checked-decode in order to avoid out of bounds access. When using the Frame format make sure to enable checksums.
+If you know your data is valid and not broken or corrupted, you can use `unchecked-decode` feature-flag to get a little bit more performance.
 ```
-lz4_flex = { version = "0.10", default-features = false, features = ["checked-decode"] }
+lz4_flex = { version = "0.10", default-features = false, features = ["unchecked-decode"] }
 ```
 
 ```rust

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -19,8 +19,7 @@ arbitrary = { version = "1", features = ["derive"] }
 libfuzzer-sys = "0.4"
 lzzzz = "0.8"
 
-# checked-decode" is required for the fuzz_decomp_corrupted_data target
-lz4_flex = { path = "..", default-features = false, features=["frame", "checked-decode"] }
+lz4_flex = { path = "..", default-features = false, features=["frame"] }
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/miri_tests/Cargo.toml
+++ b/miri_tests/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 rand = "0.8.5"
-lz4_flex = { path = "..", default-features = false, features=["frame", "checked-decode"] }
+lz4_flex = { path = "..", default-features = false, features=["frame"] }
 

--- a/src/block/decompress_safe.rs
+++ b/src/block/decompress_safe.rs
@@ -184,7 +184,7 @@ pub(crate) fn decompress_internal<const USE_DICT: bool, S: Sink>(
             if literal_length > input.len() - input_pos {
                 return Err(DecompressError::LiteralOutOfBounds);
             }
-            #[cfg(feature = "checked-decode")]
+            #[cfg(not(feature = "unchecked-decode"))]
             if literal_length > output.capacity() - output.pos() {
                 return Err(DecompressError::OutputTooSmall {
                     expected: output.pos() + literal_length,
@@ -217,7 +217,7 @@ pub(crate) fn decompress_internal<const USE_DICT: bool, S: Sink>(
             match_length += read_integer(input, &mut input_pos)? as usize;
         }
 
-        #[cfg(feature = "checked-decode")]
+        #[cfg(not(feature = "unchecked-decode"))]
         if output.pos() + match_length > output.capacity() {
             return Err(DecompressError::OutputTooSmall {
                 expected: output.pos() + match_length,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,8 +60,9 @@
 //!
 //! - `safe-encode` uses only safe rust for encode. _enabled by default_
 //! - `safe-decode` uses only safe rust for encode. _enabled by default_
-//! - `checked-decode` will add additional checks if `safe-decode` is not enabled, to avoid out of
-//!   bounds access. This should be enabled for untrusted input.
+//! - `unchecked-decode` will remove checks to avoid out of
+//!   bounds reads on corrupted data. This should be only enabled for trusted input (e.g.
+//!   checksummed).
 //! - `frame` support for LZ4 frame format. _implies `std`, enabled by default_
 //! - `std` enables dependency on the standard library. _enabled by default_
 //!

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -320,22 +320,20 @@ fn print_compression_ration(input: &'static [u8], name: &str) {
 // }
 
 #[cfg(test)]
+#[cfg(not(feature = "unchecked-decode"))]
 mod checked_decode {
     use super::*;
 
-    #[cfg_attr(not(feature = "checked-decode"), ignore)]
     #[test]
     fn error_case_1() {
         let _err = decompress_size_prepended(&[122, 1, 0, 1, 0, 10, 1, 0]);
     }
-    #[cfg_attr(not(feature = "checked-decode"), ignore)]
     #[test]
     fn error_case_2() {
         let _err = decompress_size_prepended(&[
             44, 251, 49, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 0, 0,
         ]);
     }
-    #[cfg_attr(not(feature = "checked-decode"), ignore)]
     #[test]
     fn error_case_3() {
         let _err = decompress_size_prepended(&[
@@ -343,13 +341,11 @@ mod checked_decode {
         ]);
     }
 
-    #[cfg_attr(not(feature = "checked-decode"), ignore)]
     #[test]
     fn error_case_4() {
         let _err = decompress_size_prepended(&[0, 61, 0, 0, 0, 7, 0]);
     }
 
-    #[cfg_attr(not(feature = "checked-decode"), ignore)]
     #[test]
     fn error_case_5() {
         let _err = decompress_size_prepended(&[8, 0, 0, 0, 4, 0, 0, 0]);
@@ -514,7 +510,7 @@ fn test_decomp(data: &[u8]) {
 fn bug_fuzz_7() {
     #[cfg(not(feature = "safe-decode"))]
     {
-        #[cfg(not(feature = "checked-decode"))]
+        #[cfg(feature = "unchecked-decode")]
         {
             return;
         }
@@ -528,7 +524,7 @@ fn bug_fuzz_7() {
 }
 
 // TODO maybe also not panic for default feature flags
-#[cfg(all(not(feature = "safe-decode"), feature = "checked-decode"))]
+#[cfg(all(not(feature = "safe-decode"), feature = "unchecked-decode"))]
 #[test]
 fn bug_fuzz_8() {
     let data = &[


### PR DESCRIPTION
invert `checked-decode` feature flag to `unchecked-decode`
Previously setting `default-features=false` removed the bounds checks from the
`checked-decode` feature flag. This change inverts this, so it will needs to be
deliberately deactivated.
