### PR TITLE
Remove bounds checks from `extend_from_within_overlapping`

### DIFF
--- a/src/sink.rs
+++ b/src/sink.rs
@@ -188,7 +188,7 @@ impl<'a> Sink for SliceSink<'a> {
     #[cfg(feature = "safe-decode")]
     #[cfg_attr(nightly, optimize(size))] // to avoid loop unrolling
     fn extend_from_within_overlapping(&mut self, start: usize, num_bytes: usize) {
-        for window in std::cell::Cell::from_mut(&mut self.output[start..self.pos + num_bytes])
+        for window in core::cell::Cell::from_mut(&mut self.output[start..self.pos + num_bytes])
             .as_slice_of_cells()
             .windows(self.pos - start + 1)
         {

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -189,11 +189,11 @@ impl<'a> Sink for SliceSink<'a> {
     #[cfg_attr(nightly, optimize(size))] // to avoid loop unrolling
     fn extend_from_within_overlapping(&mut self, start: usize, num_bytes: usize) {
         for window in std::cell::Cell::from_mut(&mut self.output[start..self.pos + num_bytes])
-        .as_slice_of_cells()
-        .windows(self.pos - start + 1)
-    {
-        window.last().unwrap().set(window[0].get());
-    }
+            .as_slice_of_cells()
+            .windows(self.pos - start + 1)
+        {
+            window.last().unwrap().set(window[0].get());
+        }
         self.pos += num_bytes;
     }
 }


### PR DESCRIPTION
Use an iterator to avoid bounds checks.

You can't use `slice.windows()` on mutable slices because that would result in overlapping mutable slices if `.collect()`ed, but you can turn a `&mut [u8]` into `&[Cell<u8>]` and copy the `u8`s one by one.

Godbolt showing no bounds checks in the hot loop (under `.LBB0_5:`): https://godbolt.org/z/aEcj7WYjf