### PR TITLE
remove unchecked-decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-0.11.0 (2023-06-03)
+
+0.11.1 (2023-06-19)
+==================
+
+- [**breaking**] remove `unchecked-decode`
+Remove `unchecked-decode` feature-flag, because of feature unification:
+https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
+
+0.11.0 (2023-06-18)
 ==================
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -54,15 +54,6 @@ Performance:
 lz4_flex = { version = "0.11", default-features = false }
 ```
 
-If you know guaranteed your data is valid and not broken or corrupted, you can use `unchecked-decode` feature-flag to get a little bit more performance during decompression.
-Ususally you don't want this, use case may be:
-- Compression/Decompression happens in memory.
-- The compression runs sandboxed so out of bounds reads/writes are not a problem.
-- The data is checked against a checksum.
-```
-lz4_flex = { version = "0.11", default-features = false, features = ["unchecked-decode"] }
-```
-
 ### Block Format
 The block format is only valid for smaller data chunks as as block is de/compressed in memory.
 For larger data use the frame format, which consists of multiple blocks.
@@ -132,12 +123,7 @@ This fuzz target asserts compression with cpp and decompression with lz4_flex re
 ## TODO
 - High compression
 
-## Migrate from v0.10 to v0.11
-0.11 inverts `checked-decode` feature flag to `unchecked-decode`.
-Previously setting `default-features=false` removed the bounds checks from the
-`checked-decode` feature flag. `unchecked-decode` inverts this, so it will needs to be
-deliberately deactivated.
-
-To migrate, just remove the `checked-decode` feature flag if you use it.
+## Migrate from v0.10 to v0.11.1
+To migrate, just remove the `checked-decode` feature flag if you used it.
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,6 @@
 //!
 //! - `safe-encode` uses only safe rust for encode. _enabled by default_
 //! - `safe-decode` uses only safe rust for encode. _enabled by default_
-//! - `unchecked-decode` will remove checks to avoid out of
-//!   bounds reads on corrupted data. This should be only enabled for trusted input (e.g.
-//!   checksummed).
 //! - `frame` support for LZ4 frame format. _implies `std`, enabled by default_
 //! - `std` enables dependency on the standard library. _enabled by default_
 //!


### PR DESCRIPTION
`unchecked-decode` could spill to other parts of the code due to [feature-unification](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification).

Open an issue if you want `unchecked-decode`, and I'll add `unsafe` functions for it
