### PR TITLE
Add LICENSE file to cargo package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/pseitz/lz4_flex"
 readme = "README.md"
 license = "MIT"
 version = "0.11.1"
-include = ["src/*.rs", "src/frame/**/*", "src/block/**/*", "README.md"]
+include = ["src/*.rs", "src/frame/**/*", "src/block/**/*", "README.md", "LICENSE"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This is required by MIT terms "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software."

Some tools will check for the file to be present before vendoring.