### PR TITLE
don't bring in the `fastcpy_unsafe` module with `safe-*` features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,8 @@ pub mod frame;
 
 #[allow(dead_code)]
 mod fastcpy;
+
+#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
 #[allow(dead_code)]
 mod fastcpy_unsafe;
 


### PR DESCRIPTION
No functional changes intended.

This makes it build successfully in an environment with `--deny=unsafe_code`, e.g.:
```
RUSTFLAGS=--deny=unsafe_code cargo build
```