### PR TITLE
README.md typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ AMD Ryzen 7 5900HX, rustc 1.69.0 (84c898d65 2023-04-16), Manjaro, CPU Boost Disa
 - 32-bit support
 
 ## Usage: 
-Compression and decompression uses no usafe via the default feature flags "safe-encode" and "safe-decode". If you need more performance you can disable them (e.g. with no-default-features).
+Compression and decompression uses no unsafe via the default feature flags "safe-encode" and "safe-decode". If you need more performance you can disable them (e.g. with no-default-features).
 
 Safe:
 ```


### PR DESCRIPTION
"usafe" ought to be "unsafe" i think 