### PR TITLE
Upgrade to twox-hash 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ std = []
 nightly = []
 
 [dependencies]
-twox-hash = { version = "1.6.3", default-features = false, optional = true }
+twox-hash = { version = "2.0.0", default-features = false, features = ["xxhash32"], optional = true }
 
 [profile.bench]
 codegen-units = 1

--- a/src/frame/compress.rs
+++ b/src/frame/compress.rs
@@ -311,9 +311,7 @@ impl<W: io::Write> FrameEncoder<W> {
         self.w.write_all(&block_info_buffer[..])?;
         self.w.write_all(block_data)?;
         if self.frame_info.block_checksums {
-            let mut block_hasher = XxHash32::with_seed(0);
-            block_hasher.write(block_data);
-            let block_checksum = block_hasher.finish() as u32;
+            let block_checksum = XxHash32::oneshot(0, block_data);
             self.w.write_all(&block_checksum.to_le_bytes())?;
         }
 


### PR DESCRIPTION
Thanks for using my crate!

Note that version 2.0 increases the MSRV to Rust 1.81. I understand if you don't want to upgrade right away, but hopefully this PR will be useful when you do.

I'm opening these PRs for the top users of twox-hash and have no current plans to become a consistent contributor to this specific repository; please feel free to rewrite the commit as appropriate for your project's requirements.