### PR TITLE
Use core instead of std Error

### DIFF
--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -30,7 +30,7 @@ pub(crate) mod decompress;
 pub use compress::*;
 pub use decompress::*;
 
-use core::fmt;
+use core::{error::Error, fmt};
 
 pub(crate) const WINDOW_SIZE: usize = 64 * 1024;
 
@@ -137,11 +137,9 @@ impl fmt::Display for CompressError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DecompressError {}
+impl Error for DecompressError {}
 
-#[cfg(feature = "std")]
-impl std::error::Error for CompressError {}
+impl Error for CompressError {}
 
 /// This can be used in conjunction with `decompress_size_prepended`.
 /// It will read the first 4 bytes as little-endian encoded length, and return


### PR DESCRIPTION
This impls `Error` from core (available since [rust 1.81](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html)) even in a no_std environment.