### PR TITLE
Remove bounds checks from `extend_from_within_overlapping`

### DIFF
--- a/src/sink.rs
+++ b/src/sink.rs
@@ -189,7 +189,7 @@ impl Sink for SliceSink<'_> {
     #[cfg(feature = "safe-decode")]
     #[cfg_attr(feature = "nightly", optimize(size))] // to avoid loop unrolling
     fn extend_from_within_overlapping(&mut self, start: usize, num_bytes: usize) {
-        use std::cell::Cell;
+        use core::cell::Cell;
         let offset = self.pos - start;
         let slice_of_cells: &[Cell<u8>] = Cell::from_mut(self.output).as_slice_of_cells();
         let input = &slice_of_cells[start..];

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -192,8 +192,8 @@ impl Sink for SliceSink<'_> {
         use std::cell::Cell;
         let offset = self.pos - start;
         let slice_of_cells: &[Cell<u8>] = Cell::from_mut(self.output).as_slice_of_cells();
-        let input = &slice_of_cells[start..][..offset.saturating_add(num_bytes)];
-        let output = &input[offset..];
+        let input = &slice_of_cells[start..];
+        let output = &input[offset..][..num_bytes];
         for (in_byte, out_byte) in input.iter().zip(output.iter()) {
             out_byte.set(in_byte.get());
         }


### PR DESCRIPTION
I came across a challenge to remove bounds checks from this function in https://flexineering.com/posts/lz4-011/

This is the code currently in tree: https://godbolt.org/z/W3zqcbnd5

This is the proposed code: https://godbolt.org/z/an1sYhc4c

As you can see, all the bounds checks from the hot loop are gone. On the flip side, there is more assembly total. Not sure why, perhaps the compiler unrolls the loop more aggressively?

It's possible to get the amount of bounds checks down to 2, but that produces even more assembly: https://godbolt.org/z/dKfbcv98r 
You can try this version if you check out commit dd23da8e50cb585e7ff4bb874cad06b2e67c1f13 

I have not benchmarked whether this is actually faster or slower in practice. It's possible that the increase in the total amount of assembly loaded into instruction cache will offset the gains from removing the already perfectly predictable branches of the bounds checks.

This is likely going to run into all the same issues as #141, but I wanted to give it another try.