### PR TITLE
Fix incorrect rust-version field name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 version = "0.11.4"
 include = ["src/*.rs", "src/frame/**/*", "src/block/**/*", "README.md", "LICENSE"]
-rust_version = "1.81"
+rust-version = "1.81"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Thanks for the great work 💪 

Sadly the field name for the `rust-version` was misspelled and it broke our MSRV check in https://github.com/open-telemetry/opentelemetry-rust-contrib

It would be possible to release a new version with the fix and yank the recently published one `0.11.4`? We are using the quite new dependency version fallback resolver to automatically download the highest supported version and because of the misspelled field name it will downloaded in projects with a lower MSRV of 1.81.