### PR TITLE
add minimal security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+Please report potential security vulnerabilities privately through GitHub:\
+https://github.com/PSeitz/lz4_flex/security/advisories/new
+
+If you are unsure whether something represents a vulnerability, please report it privately nonetheless.
+We can then evaluate it together and decide how to handle the issue.


### PR DESCRIPTION
Resolves #199

To draw attention to the enabled "private vulnerability reporting" feature. Because unlike the SECURITY.md file which is prominently shown in a few places in the GitHub UI, the "private vulnerability reporting" feature can be difficult to find in case users are not aware that it exists.

Here are a few places where this SECURITY.md is shown:
- Tab on the main page
![Screenshot main page](https://github.com/user-attachments/assets/3fe47b3b-a93e-4f1c-aba1-57e60d619b0e)
- Sidebar
![Screenshot sidebar](https://github.com/user-attachments/assets/ea5aac9d-f96f-4f8b-85cc-62e665cadf0c)
- When using issue templates and the user creates a new issue (does not apply here, since this repository does not use issue templates)

Feel free to adjust the policy file as you like though, for example:
- mention things which are / are not considered vulnerabilities
(maybe that is only needed if you get a lot of bogus reports)
- mention the time frame in which users can expect a result, e.g. in case you are busy with other projects, so that users know that it can take a few days
