### PR TITLE
frame compressor uses CompressTable

### DIFF
--- a/src/block/compress.rs
+++ b/src/block/compress.rs
@@ -720,7 +720,43 @@ impl Default for CompressTable {
     }
 }
 
+impl HashTable for CompressTable {
+    #[inline]
+    fn get_at(&self, pos: usize) -> usize {
+        match self {
+            CompressTable::Small(t) => t.get_at(pos),
+            CompressTable::Large(t) => t.get_at(pos),
+        }
+    }
+
+    #[inline]
+    fn put_at(&mut self, pos: usize, val: usize) {
+        match self {
+            CompressTable::Small(t) => t.put_at(pos, val),
+            CompressTable::Large(t) => t.put_at(pos, val),
+        }
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        match self {
+            CompressTable::Small(t) => t.clear(),
+            CompressTable::Large(t) => t.clear(),
+        }
+    }
+}
+
 impl CompressTable {
+    /// Shifts all entries down by `offset`, clamping at zero.
+    ///
+    /// Only supported for `Large` tables; panics if called on a `Small` table.
+    pub fn reposition(&mut self, offset: u32) {
+        match self {
+            CompressTable::Large(t) => t.reposition(offset),
+            CompressTable::Small(_) => panic!("reposition is not supported on small tables"),
+        }
+    }
+
     /// Create a small table (16-bit entries). More memory efficient, but only usable when the
     /// total input size is less than 65535 bytes.
     pub fn small() -> Self {

--- a/src/block/hashtable.rs
+++ b/src/block/hashtable.rs
@@ -33,15 +33,21 @@ fn hash5(sequence: usize) -> u32 {
     (((sequence << 24).wrapping_mul(primebytes)) >> 48) as u32
 }
 
+/// Trait for hash tables used during LZ4 compression.
 pub trait HashTable {
+    /// Returns the value stored at the given hash position.
     fn get_at(&self, pos: usize) -> usize;
+    /// Stores a value at the given hash position.
     fn put_at(&mut self, pos: usize, val: usize);
+    /// Resets all entries to zero.
     fn clear(&mut self);
+    /// Computes a hash for the bytes at `pos` in `input`.
     #[inline]
     #[cfg(target_pointer_width = "64")]
     fn get_hash_at(input: &[u8], pos: usize) -> usize {
         hash5(super::compress::get_batch_arch(input, pos)) as usize
     }
+    /// Computes a hash for the bytes at `pos` in `input`.
     #[inline]
     #[cfg(target_pointer_width = "32")]
     fn get_hash_at(input: &[u8], pos: usize) -> usize {
@@ -134,12 +140,14 @@ impl HashTable for HashTable4K {
 const HASHTABLE_SIZE_8K: usize = 8 * 1024;
 const HASH_TABLE_BIT_SHIFT_8K: usize = 3;
 
+/// An 8K entry hash table using 32-bit values.
 #[derive(Debug)]
 pub struct HashTable8K {
     dict: Box<[u32; HASHTABLE_SIZE_8K]>,
 }
 #[allow(dead_code)]
 impl HashTable8K {
+    /// Creates a new zeroed hash table.
     #[inline]
     pub fn new() -> Self {
         let dict = alloc::vec![0; HASHTABLE_SIZE_8K]

--- a/src/frame/compress.rs
+++ b/src/frame/compress.rs
@@ -7,8 +7,8 @@ use twox_hash::XxHash32;
 
 use crate::{
     block::{
-        compress::compress_internal,
-        hashtable::{HashTable, HashTable4K},
+        compress::{compress_internal, CompressTable},
+        hashtable::HashTable,
     },
     sink::vec_sink_for_compression,
 };
@@ -74,7 +74,7 @@ pub struct FrameEncoder<W: io::Write> {
     /// _Not_ the same as `content_len` as this is reset every to 2GB.
     src_stream_offset: usize,
     /// Encoder table
-    compression_table: HashTable4K,
+    compression_table: CompressTable,
     /// The underlying writer.
     w: W,
     /// Xxhash32 used when content checksum is enabled.
@@ -137,7 +137,7 @@ impl<W: io::Write> FrameEncoder<W> {
             src: Vec::new(),
             w: wtr,
             // 16 KB hash table for matches, same as the reference implementation.
-            compression_table: HashTable4K::new(),
+            compression_table: CompressTable::default(),
             content_hasher: XxHash32::with_seed(0),
             content_len: 0,
             dst: Vec::new(),
@@ -235,6 +235,9 @@ impl<W: io::Write> FrameEncoder<W> {
         self.is_frame_open = true;
         if self.frame_info.block_size == BlockSize::Auto {
             self.frame_info.block_size = BlockSize::from_buf_length(buf_len);
+        }
+        if self.frame_info.block_size.get_size() > u16::MAX as usize {
+            self.compression_table = CompressTable::large();
         }
         self.init();
         let mut frame_info_buffer = [0u8; MAX_FRAME_INFO_SIZE];


### PR DESCRIPTION
Follow-up to https://github.com/PSeitz/lz4_flex/pull/207. The frame compressor can utilize the `CompressTable` which will start out with `HashTable4KU16` and will grow to `HashTable4K` when needed, optimizing for small blocksizes.