### PR TITLE
Fix panic in From<io::Error> implementation for frame::Error

### DIFF
--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -95,7 +95,7 @@ impl From<Error> for io::Error {
 
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
-        match e.get_ref().map(|e| e.downcast_ref::<Error>()) {
+        match e.get_ref().and_then(|e| e.downcast_ref::<Error>()) {
             Some(_) => *e.into_inner().unwrap().downcast::<Error>().unwrap(),
             None => Error::IoError(e),
         }


### PR DESCRIPTION
The `From` implementation for converting an `io::Error` to a `frame::Error` always panics for custom IO errors.

This is the current implementation:
```rust
impl From<io::Error> for Error {
    fn from(e: io::Error) -> Self {
        match e.get_ref().map(|e| e.downcast_ref::<Error>()) {
            Some(_) => *e.into_inner().unwrap().downcast::<Error>().unwrap(),
            None => Error::IoError(e),
        }
    }
}
```
This will always panic on the last `unwrap()` for any kind of custom IO error that is not a wrapped `frame::Error`, regardless of whether `e.downcast_ref::<Error>()` actually succeeded.

I changed the `map()` call to `and_then()`, which is probably the originally intended behaviour.

Found this bug while testing error propagation in my own LZ4 stream wrapper implementation, which uses lz4_flex as a backend.