### PR TITLE
Refactor test assert macros from more_assert to assertables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dev-dependencies]
 lzzzz = "2.0.0"
 lz4-compress = "0.1.1"
-more-asserts = "0.3.1"
+assertables = "10.0.0"
 snap = "1.1.0"
 serde_json = "1.0.91"
 proptest = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,7 @@
 extern crate alloc;
 
 #[cfg(test)]
-#[macro_use] extern crate assertables;
+extern crate assertables;
 
 pub mod block;
 #[cfg(feature = "frame")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,8 +78,7 @@
 extern crate alloc;
 
 #[cfg(test)]
-#[macro_use]
-extern crate more_asserts;
+#[macro_use] extern crate assertables;
 
 pub mod block;
 #[cfg(feature = "frame")]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,7 +1,6 @@
 //! Tests.
 
-#[macro_use]
-extern crate more_asserts;
+use assertables::*;
 
 use std::iter;
 


### PR DESCRIPTION
Purpose: update lz4_flex test macros from an older crate `more_asserts` to a  newer crate `assertables`. This provides more capabilities for semantic testing, especially doing production runtime testing without using debug_assert_*.

https://crates.io/crates/assertables

Context: I'm using LZ4 for near-real-time sending of extensive data for medical purposes, and when I looked at your Cargo.toml I saw a small bit where I may be able to help. This commit is a tiny first step to ask if the lz4_flex maintainers may be potentially open using `assertables`.

Who I am: I'm the author of a drop-in-replacement crate `assertables` that provides many more assert macros, and has multiple code forges (GitHub, GitLab, Codeberg), and has more widespread licensing options (MIT, BSD, GPL, Apache). I've hand-written every line, no AI. I work at a nonprofit public sector healthcare agency, and I'm seeking to scale up semantic testing because it helps improves readability, maintainability, and security.

The broader purpose: I'm gradually asking a bunch of open source projects to consider using `assertables`, and ideally if possible providing contructive feedback about more capabilities for testing could help you. 

For lz4_flex, for example, you have a test like this:

```rust
assert!(x.len() < y.len())
```

With this crate, you can write this better and get better error messages as well:

```rust
assert_len_lt!(x, y)
```

The crate also makes it easy to import just the tests you want, which I recommend, such as:

```rust
use assertables::{assert_lt, assert_gt};
```

I know this doesn't sound like much, yet these improvements add up over time, and add up as they reach more projects. I'm aiming to gradually encourage Rust coders to use more semantic tests.

Thank you for your consideration. Happy to chat about it, if you like. My direct personal email is joel@joelparkerhenderson.com (and I know this message is public).