### PR TITLE
Add alloc feature to support no_std without an allocator

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,10 @@ jobs:
       run: cargo build --no-default-features --features safe-encode
     - name: Ensure no_std compiles for safe-encode and safe-decode
       run: cargo build --no-default-features --features safe-encode --features safe-decode
+    - name: Ensure no_std compiles with alloc
+      run: cargo build --no-default-features --features alloc
+    - name: Ensure no_std compiles with alloc for safe-encode and safe-decode
+      run: cargo build --no-default-features --features alloc --features safe-encode --features safe-decode
     - name: Build
       run: cargo build --verbose
     - name: Check Formatting
@@ -47,6 +51,10 @@ jobs:
       run: cargo +nightly test --no-default-features --features frame --features nightly
     - name: Run tests unsafe with checked-decode and frame
       run: cargo test --no-default-features --features frame
+    - name: Run tests without alloc
+      run: cargo test --no-default-features --test no_alloc
+    - name: Run tests without alloc for safe-encode and safe-decode
+      run: cargo test --no-default-features --features safe-encode --features safe-decode --test no_alloc
     - name: Install cargo fuzz
       run: cargo install cargo-fuzz
     - name: Run fuzz tests (safe)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+0.14.0 (unreleased)
+==================
+### Features
+- Add `alloc` feature to allow `no_std` operation without an allocator. The `std` feature now implies `alloc`. Without `alloc` only the `_into` variants of the block API are available, e.g. `compress_into`; the compression hash table is placed on the stack or can be provided via `compress_into_with_table`.
+```
+Note: Users with `default-features = false` need to additionally enable the `alloc`
+feature to keep the APIs returning `Vec`, e.g. `compress` and `decompress`.
+```
+
 0.13.1 (2026-05-09)
 ==================
 ### Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,8 @@ safe-decode = []
 safe-encode = []
 checked-decode = [] # Adds important checks while decoding. Only remove on trusted input!
 frame = ["std", "dep:twox-hash"]
-std = []
+std = ["alloc"]
+alloc = []
 # use nightly compiler features
 nightly = []
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ lz4_flex = { version = "0.12" }
 
 Performance:
 ```
-lz4_flex = { version = "0.12", default-features = false }
+lz4_flex = { version = "0.12", default-features = false, features = ["alloc"] }
 ```
 
 ### Block Format
@@ -73,6 +73,11 @@ fn main(){
 ## no_std support
 
 no_std support is currently only for the block format, since the frame format uses `std::io::Write`, which is not available in core.
+
+For environments without an allocator, additionally disable the `alloc` feature. The `_into` variants
+(`compress_into`, `decompress_into`, ...) operate on user-provided slices, the compression hash table is
+either placed on the stack (8-16KB depending on input size) or provided by the caller via
+`compress_into_with_table`.
 
 ## Benchmarks
 The benchmark is run with criterion, the test files are in the benches folder.

--- a/src/block/compress.rs
+++ b/src/block/compress.rs
@@ -10,13 +10,15 @@ use crate::block::LZ4_MIN_LENGTH;
 use crate::block::MAX_DISTANCE;
 use crate::block::MFLIMIT;
 use crate::block::MINMATCH;
-#[cfg(not(feature = "safe-encode"))]
+#[cfg(all(feature = "alloc", not(feature = "safe-encode")))]
 use crate::sink::PtrSink;
 use crate::sink::Sink;
 use crate::sink::SliceSink;
+#[cfg(feature = "alloc")]
 #[allow(unused_imports)]
 use alloc::vec;
 
+#[cfg(feature = "alloc")]
 #[allow(unused_imports)]
 use alloc::vec::Vec;
 
@@ -630,6 +632,7 @@ pub fn compress_into_with_dict(
     compress_into_sink_with_dict::<true>(input, &mut SliceSink::new(output, 0), dict_data)
 }
 
+#[cfg(feature = "alloc")]
 #[inline]
 fn compress_into_vec_with_dict<const USE_DICT: bool>(
     input: &[u8],
@@ -682,6 +685,7 @@ fn compress_into_vec_with_dict<const USE_DICT: bool>(
     compressed
 }
 
+#[cfg(feature = "alloc")]
 #[cold]
 #[inline(never)]
 fn compress_into_vec_without_dict(input: &[u8], prepend_size: bool) -> Vec<u8> {
@@ -690,18 +694,24 @@ fn compress_into_vec_without_dict(input: &[u8], prepend_size: bool) -> Vec<u8> {
 
 /// Compress all bytes of `input` into `output`. The uncompressed size will be prepended as a little
 /// endian u32. Can be used in conjunction with `decompress_size_prepended`
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[inline]
 pub fn compress_prepend_size(input: &[u8]) -> Vec<u8> {
     compress_into_vec_with_dict::<false>(input, true, b"")
 }
 
 /// Compress all bytes of `input`.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[inline]
 pub fn compress(input: &[u8]) -> Vec<u8> {
     compress_into_vec_with_dict::<false>(input, false, b"")
 }
 
 /// Compress all bytes of `input` with an external dictionary.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[inline]
 pub fn compress_with_dict(input: &[u8], ext_dict: &[u8]) -> Vec<u8> {
     compress_into_vec_with_dict::<true>(input, false, ext_dict)
@@ -709,6 +719,8 @@ pub fn compress_with_dict(input: &[u8], ext_dict: &[u8]) -> Vec<u8> {
 
 /// Compress all bytes of `input` into `output`. The uncompressed size will be prepended as a little
 /// endian u32. Can be used in conjunction with `decompress_size_prepended_with_dict`
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[inline]
 pub fn compress_prepend_size_with_dict(input: &[u8], ext_dict: &[u8]) -> Vec<u8> {
     compress_into_vec_with_dict::<true>(input, true, ext_dict)
@@ -744,12 +756,27 @@ impl Default for CompressTable {
 impl CompressTable {
     /// Create a small table (16-bit entries). More memory efficient, but only usable when the
     /// total input size is less than 65535 bytes.
+    #[cfg(feature = "alloc")]
     pub fn small() -> Self {
         CompressTable::Small(HashTable4KU16::new())
     }
 
+    /// Create a small table (16-bit entries). More memory efficient, but only usable when the
+    /// total input size is less than 65535 bytes.
+    #[cfg(not(feature = "alloc"))]
+    pub const fn small() -> Self {
+        CompressTable::Small(HashTable4KU16::new())
+    }
+
     /// Create a large table (32-bit entries). Works for any input size.
+    #[cfg(feature = "alloc")]
     pub fn large() -> Self {
+        CompressTable::Large(HashTable4K::new())
+    }
+
+    /// Create a large table (32-bit entries). Works for any input size.
+    #[cfg(not(feature = "alloc"))]
+    pub const fn large() -> Self {
         CompressTable::Large(HashTable4K::new())
     }
 }
@@ -763,7 +790,8 @@ impl CompressTable {
 ///
 /// **Note:** If the table variant doesn't match the input size (e.g. a `Small` table is used
 /// with input >= 64KB), the table will be transparently upgraded. However, it won't be
-/// downgraded automatically.
+/// downgraded automatically. Without the `alloc` feature the upgrade constructs the new table
+/// on the stack, use [`CompressTable::large`] upfront to avoid this.
 #[inline]
 pub fn compress_into_with_table(
     input: &[u8],

--- a/src/block/decompress.rs
+++ b/src/block/decompress.rs
@@ -1,8 +1,11 @@
 //! The block decompression algorithm.
 use crate::block::{DecompressError, MINMATCH};
 use crate::fastcpy_unsafe;
+#[cfg(feature = "alloc")]
+use crate::sink::PtrSink;
+use crate::sink::Sink;
 use crate::sink::SliceSink;
-use crate::sink::{PtrSink, Sink};
+#[cfg(feature = "alloc")]
 #[allow(unused_imports)]
 use alloc::vec::Vec;
 
@@ -474,6 +477,8 @@ pub fn decompress_into_with_dict(
 /// May panic if the parameter `min_uncompressed_size` is smaller than the
 /// uncompressed data.
 
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[inline]
 pub fn decompress_with_dict(
     input: &[u8],
@@ -492,6 +497,8 @@ pub fn decompress_with_dict(
 
 /// Decompress all bytes of `input` into a new vec. The first 4 bytes are the uncompressed size in
 /// little endian. Can be used in conjunction with `compress_prepend_size`
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[inline]
 pub fn decompress_size_prepended(input: &[u8]) -> Result<Vec<u8>, DecompressError> {
     let (uncompressed_size, input) = super::uncompressed_size(input)?;
@@ -504,6 +511,8 @@ pub fn decompress_size_prepended(input: &[u8]) -> Result<Vec<u8>, DecompressErro
 /// # Panics
 /// May panic if the parameter `min_uncompressed_size` is smaller than the
 /// uncompressed data.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[inline]
 pub fn decompress(input: &[u8], min_uncompressed_size: usize) -> Result<Vec<u8>, DecompressError> {
     // Allocate a vector to contain the decompressed stream.
@@ -518,6 +527,8 @@ pub fn decompress(input: &[u8], min_uncompressed_size: usize) -> Result<Vec<u8>,
 
 /// Decompress all bytes of `input` into a new vec. The first 4 bytes are the uncompressed size in
 /// little endian. Can be used in conjunction with `compress_prepend_size_with_dict`
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[inline]
 pub fn decompress_size_prepended_with_dict(
     input: &[u8],

--- a/src/block/decompress_safe.rs
+++ b/src/block/decompress_safe.rs
@@ -5,8 +5,10 @@ use crate::block::MINMATCH;
 use crate::sink::Sink;
 use crate::sink::SliceSink;
 
+#[cfg(feature = "alloc")]
 #[allow(unused_imports)]
 use alloc::vec;
+#[cfg(feature = "alloc")]
 #[allow(unused_imports)]
 use alloc::vec::Vec;
 
@@ -338,6 +340,8 @@ pub fn decompress_into_with_dict(
 
 /// Decompress all bytes of `input` into a new vec. The first 4 bytes are the uncompressed size in
 /// little endian. Can be used in conjunction with `compress_prepend_size`
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[inline]
 pub fn decompress_size_prepended(input: &[u8]) -> Result<Vec<u8>, DecompressError> {
     let (uncompressed_size, input) = super::uncompressed_size(input)?;
@@ -350,6 +354,8 @@ pub fn decompress_size_prepended(input: &[u8]) -> Result<Vec<u8>, DecompressErro
 /// # Panics
 /// May panic if the parameter `min_uncompressed_size` is smaller than the
 /// uncompressed data.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[inline]
 pub fn decompress(input: &[u8], min_uncompressed_size: usize) -> Result<Vec<u8>, DecompressError> {
     let mut decompressed: Vec<u8> = vec![0; min_uncompressed_size];
@@ -361,6 +367,8 @@ pub fn decompress(input: &[u8], min_uncompressed_size: usize) -> Result<Vec<u8>,
 
 /// Decompress all bytes of `input` into a new vec. The first 4 bytes are the uncompressed size in
 /// little endian. Can be used in conjunction with `compress_prepend_size_with_dict`
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[inline]
 pub fn decompress_size_prepended_with_dict(
     input: &[u8],
@@ -376,6 +384,8 @@ pub fn decompress_size_prepended_with_dict(
 /// # Panics
 /// May panic if the parameter `min_uncompressed_size` is smaller than the
 /// uncompressed data.
+#[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 #[inline]
 pub fn decompress_with_dict(
     input: &[u8],

--- a/src/block/hashtable.rs
+++ b/src/block/hashtable.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "alloc")]
 #[allow(unused_imports)]
 use alloc::boxed::Box;
 
@@ -56,10 +57,14 @@ const HASHTABLE_BIT_SHIFT_4K: usize = 4;
 #[derive(Debug)]
 #[repr(align(64))]
 pub struct HashTable4KU16 {
+    #[cfg(feature = "alloc")]
     dict: Box<[u16; HASHTABLE_SIZE_4K]>,
+    #[cfg(not(feature = "alloc"))]
+    dict: [u16; HASHTABLE_SIZE_4K],
 }
 impl HashTable4KU16 {
     /// Creates a new zeroed hash table.
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn new() -> Self {
         // This generates more efficient assembly in contrast to Box::new(slice), because of an
@@ -70,6 +75,15 @@ impl HashTable4KU16 {
             .try_into()
             .unwrap();
         Self { dict }
+    }
+
+    /// Creates a new zeroed hash table.
+    #[cfg(not(feature = "alloc"))]
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            dict: [0; HASHTABLE_SIZE_4K],
+        }
     }
 }
 impl HashTable for HashTable4KU16 {
@@ -94,10 +108,14 @@ impl HashTable for HashTable4KU16 {
 /// A 4K entry hash table using 32-bit values.
 #[derive(Debug)]
 pub struct HashTable4K {
+    #[cfg(feature = "alloc")]
     dict: Box<[u32; HASHTABLE_SIZE_4K]>,
+    #[cfg(not(feature = "alloc"))]
+    dict: [u32; HASHTABLE_SIZE_4K],
 }
 impl HashTable4K {
     /// Creates a new zeroed hash table.
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn new() -> Self {
         let dict = alloc::vec![0; HASHTABLE_SIZE_4K]
@@ -105,6 +123,15 @@ impl HashTable4K {
             .try_into()
             .unwrap();
         Self { dict }
+    }
+
+    /// Creates a new zeroed hash table.
+    #[cfg(not(feature = "alloc"))]
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            dict: [0; HASHTABLE_SIZE_4K],
+        }
     }
 
     /// Shifts all entries down by `offset`, clamping at zero.
@@ -136,10 +163,14 @@ const HASH_TABLE_BIT_SHIFT_8K: usize = 3;
 
 #[derive(Debug)]
 pub struct HashTable8K {
+    #[cfg(feature = "alloc")]
     dict: Box<[u32; HASHTABLE_SIZE_8K]>,
+    #[cfg(not(feature = "alloc"))]
+    dict: [u32; HASHTABLE_SIZE_8K],
 }
 #[allow(dead_code)]
 impl HashTable8K {
+    #[cfg(feature = "alloc")]
     #[inline]
     pub fn new() -> Self {
         let dict = alloc::vec![0; HASHTABLE_SIZE_8K]
@@ -148,6 +179,13 @@ impl HashTable8K {
             .unwrap();
 
         Self { dict }
+    }
+    #[cfg(not(feature = "alloc"))]
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            dict: [0; HASHTABLE_SIZE_8K],
+        }
     }
 }
 impl HashTable for HashTable8K {

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -3,6 +3,7 @@
 //! As defined in <https://github.com/lz4/lz4/blob/dev/doc/lz4_Block_format.md>
 //!
 //! Currently for no_std support only the block format is supported.
+//! Without the `alloc` feature only the `_into` variants are available, e.g. [`compress_into`].
 //!
 //! # Example: block format roundtrip
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,11 +61,19 @@
 //! - `safe-encode` uses only safe rust for encode. _enabled by default_
 //! - `safe-decode` uses only safe rust for encode. _enabled by default_
 //! - `frame` support for LZ4 frame format. _implies `std`, enabled by default_
-//! - `std` enables dependency on the standard library. _enabled by default_
+//! - `std` enables dependency on the standard library. _implies `alloc`, enabled by default_
+//! - `alloc` enables APIs that allocate, e.g. [`compress`](block/fn.compress.html) returning a
+//!   `Vec`. _enabled by default_
 //!
 //! For maximum performance use `no-default-features`.
 //!
 //! For no_std support only the [`block format`](block/index.html) is supported.
+//!
+//! Without the `alloc` feature only the `_into` variants are available, e.g.
+//! [`compress_into`](block/fn.compress_into.html). Compression then places its hash table
+//! (8-16KB) on the stack. Alternatively
+//! [`compress_into_with_table`](block/fn.compress_into_with_table.html) can be used with a
+//! statically allocated [`CompressTable`](block/enum.CompressTable.html).
 //!
 //!
 #![deny(warnings)]
@@ -74,6 +82,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "nightly", feature(optimize_attribute))]
 
+#[cfg(feature = "alloc")]
 #[cfg_attr(test, macro_use)]
 extern crate alloc;
 
@@ -97,12 +106,24 @@ mod fastcpy_unsafe;
     since = "0.11.0",
     note = "This re-export is deprecated as it can be confused with the frame API and is not suitable for very large data, use block:: instead"
 )]
-pub use block::{compress, compress_into, compress_prepend_size};
+pub use block::compress_into;
 #[deprecated(
     since = "0.11.0",
     note = "This re-export is deprecated as it can be confused with the frame API and is not suitable for very large data, use block:: instead"
 )]
-pub use block::{decompress, decompress_into, decompress_size_prepended};
+pub use block::decompress_into;
+#[cfg(feature = "alloc")]
+#[deprecated(
+    since = "0.11.0",
+    note = "This re-export is deprecated as it can be confused with the frame API and is not suitable for very large data, use block:: instead"
+)]
+pub use block::{compress, compress_prepend_size};
+#[cfg(feature = "alloc")]
+#[deprecated(
+    since = "0.11.0",
+    note = "This re-export is deprecated as it can be confused with the frame API and is not suitable for very large data, use block:: instead"
+)]
+pub use block::{decompress, decompress_size_prepended};
 
 #[cfg_attr(
     all(feature = "safe-encode", feature = "safe-decode"),

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "alloc")]
 #[allow(unused_imports)]
 use alloc::vec::Vec;
 
@@ -44,6 +45,7 @@ pub fn vec_sink_for_decompression(
 pub trait Sink {
     /// Returns a raw ptr to the first unfilled byte of the Sink. Analogous to `[pos..].as_ptr()`.
     #[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+    #[allow(dead_code)]
     unsafe fn pos_mut_ptr(&mut self) -> *mut u8;
 
     /// read byte at position
@@ -202,7 +204,10 @@ impl Sink for SliceSink<'_> {
 /// space.
 ///
 ///
-#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+#[cfg(all(
+    feature = "alloc",
+    not(all(feature = "safe-encode", feature = "safe-decode"))
+))]
 pub struct PtrSink {
     /// The working slice, which may contain uninitialized bytes
     output: *mut u8,
@@ -212,7 +217,10 @@ pub struct PtrSink {
     cap: usize,
 }
 
-#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+#[cfg(all(
+    feature = "alloc",
+    not(all(feature = "safe-encode", feature = "safe-decode"))
+))]
 impl PtrSink {
     /// Creates a `Sink` backed by the given byte slice.
     /// `pos` defines the initial output position in the Sink.
@@ -235,7 +243,10 @@ impl PtrSink {
     }
 }
 
-#[cfg(not(all(feature = "safe-encode", feature = "safe-decode")))]
+#[cfg(all(
+    feature = "alloc",
+    not(all(feature = "safe-encode", feature = "safe-decode"))
+))]
 impl Sink for PtrSink {
     /// Returns a raw ptr to the first unfilled byte of the Sink. Analogous to `[pos..].as_ptr()`.
     #[inline]

--- a/tests/no_alloc.rs
+++ b/tests/no_alloc.rs
@@ -1,0 +1,29 @@
+//! Roundtrip without the `alloc` feature, using only the `_into` APIs.
+//! Run with: cargo test --no-default-features --test no_alloc
+#![cfg(not(feature = "alloc"))]
+
+use lz4_flex::block::{
+    compress_into, compress_into_with_table, decompress_into, get_maximum_output_size,
+    CompressTable,
+};
+
+static mut TABLE: CompressTable = CompressTable::large();
+
+#[test]
+fn heapless_roundtrip() {
+    let input = b"Hello people, what's up? Hello people, what's up? Hello!";
+    let mut compressed = [0u8; 256];
+    assert!(get_maximum_output_size(input.len()) <= compressed.len());
+
+    // stack-allocated hash table
+    let len = compress_into(input, &mut compressed).unwrap();
+    let mut decompressed = [0u8; 256];
+    let dlen = decompress_into(&compressed[..len], &mut decompressed).unwrap();
+    assert_eq!(&decompressed[..dlen], input);
+
+    // statically allocated hash table
+    let table = unsafe { &mut *core::ptr::addr_of_mut!(TABLE) };
+    let len = compress_into_with_table(input, &mut compressed, table).unwrap();
+    let dlen = decompress_into(&compressed[..len], &mut decompressed).unwrap();
+    assert_eq!(&decompressed[..dlen], input);
+}


### PR DESCRIPTION
Gate the Vec-returning block APIs behind a new alloc feature, enabled by default via std. Without it only the _into variants are available; compression places its hash table on the stack, or the table can be provided via compress_into_with_table, with const constructors so it can be stored in a static.

Fixes: #220 