### PR TITLE
feat: ultra mode, an optimal-parse LZ4 compressor

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,10 @@ jobs:
       run: cargo build --no-default-features --features safe-encode
     - name: Ensure no_std compiles for safe-encode and safe-decode
       run: cargo build --no-default-features --features safe-encode --features safe-decode
+    - name: Ensure no_std compiles for ultra
+      run: cargo build --no-default-features --features ultra
+    - name: Ensure no_std compiles for ultra (all-safe)
+      run: cargo build --no-default-features --features ultra --features safe-encode --features safe-decode
     - name: Build
       run: cargo build --verbose
     - name: Check Formatting
@@ -47,6 +51,10 @@ jobs:
       run: cargo +nightly test --no-default-features --features frame --features nightly
     - name: Run tests unsafe with checked-decode and frame
       run: cargo test --no-default-features --features frame
+    - name: Run tests ultra (default + frame)
+      run: cargo test --features ultra --features frame
+    - name: Run tests ultra unsafe (no-default-features)
+      run: cargo test --no-default-features --features std --features frame --features ultra
     - name: Install cargo fuzz
       run: cargo install cargo-fuzz
     - name: Run fuzz tests (safe)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ safe-encode = []
 checked-decode = [] # Adds important checks while decoding. Only remove on trusted input!
 frame = ["std", "dep:twox-hash"]
 std = []
+# Optimal-parse "ultra" block compressor (slower, higher ratio). Pure Rust, no extra deps.
+# Produces standard LZ4 blocks decodable by any LZ4 decompressor. Requires alloc.
+ultra = []
 # use nightly compiler features
 nightly = []
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ AMD Ryzen 7 5900HX, rustc 1.69.0 (84c898d65 2023-04-16), Manjaro, CPU Boost Disa
 - Feature flags to configure safe/unsafe code usage
 - no-std support with block format (thanks @coolreader18)
 - 32-bit support
+- Optional optimal-parse `ultra` mode for maximum compression ratio (pure-Rust port of [lz4ultra](https://github.com/emmanuel-marty/lz4ultra))
 
 ## Usage: 
 Compression and decompression uses no unsafe via the default feature flags "safe-encode" and "safe-decode". If you need more performance you can disable them (e.g. with no-default-features).
@@ -67,6 +68,46 @@ fn main(){
     let uncompressed = decompress_size_prepended(&compressed).unwrap();
     assert_eq!(input, uncompressed);
 }
+```
+
+### Ultra mode (optimal parsing)
+
+Enable the `ultra` feature for an optimal-parse compressor — a pure-Rust port of
+[lz4ultra](https://github.com/emmanuel-marty/lz4ultra). It compresses noticeably smaller than the
+default fast parser (matching `lz4hc -12` / `lz4ultra` byte-for-byte), at the cost of speed and
+memory. The output is a standard LZ4 block/frame, decodable by any LZ4 decompressor.
+
+```toml
+lz4_flex = { version = "0.13", features = ["ultra"] }
+```
+
+```rust
+use lz4_flex::block::{compress_with_mode, decompress, CompressionMode};
+
+let input: &[u8] = b"Hello people, what's up? Hello people, what's up?";
+// `b""` is the (empty) dictionary; pass a slice to compress against one.
+let compressed = compress_with_mode(input, b"", CompressionMode::Ultra);
+let uncompressed = decompress(&compressed, input.len()).unwrap();
+assert_eq!(input, uncompressed);
+```
+
+The optimal-parse engine is chosen with [`CompressionMode`]:
+
+- `CompressionMode::Ultra` — a faithful port of [lz4ultra](https://github.com/emmanuel-marty/lz4ultra):
+  a suffix-array match finder feeding a global optimal-parse DP, producing a decode-optimised LZ4
+  stream (it decompresses faster than `lz4hc` at the same ratio — it favours decompression speed,
+  lz4ultra's own default). Best ratio, but the slowest and most memory-hungry.
+- `CompressionMode::Hc` — a port of LZ4's `LZ4HC_compress_optimal` (level 12, byte-identical to
+  `lz4hc -12`): ratio close to `Ultra`, **several times faster**, far less memory.
+- `CompressionMode::Fast` — the default greedy/lazy compressor (same as `compress`).
+
+The same `CompressionMode` works for the frame format:
+
+```rust,ignore
+use lz4_flex::frame::{CompressionMode, FrameEncoder};
+
+let mut enc = FrameEncoder::new(Vec::new());
+enc.set_compression_mode(CompressionMode::Hc);
 ```
 
 

--- a/benches/binggan_bench.rs
+++ b/benches/binggan_bench.rs
@@ -136,6 +136,21 @@ fn block_compress(mut runner: InputGroup<Vec<u8>, usize>) {
         let out = black_box(lz4_cpp_block_compress(i).unwrap());
         out.len()
     });
+    // Optimal-parse comparison: our ultra vs the C reference lz4hc at max level.
+    #[cfg(feature = "ultra")]
+    runner.register("lz4 flex ultra", move |i| {
+        let out = black_box(lz4_flex::block::compress_with_mode(
+            i,
+            b"",
+            lz4_flex::block::CompressionMode::Ultra,
+        ));
+        out.len()
+    });
+    runner.register("lz4 c hc12", move |i| {
+        let mut out = Vec::new();
+        lzzzz::lz4_hc::compress_to_vec(i, &mut out, lzzzz::lz4_hc::CLEVEL_MAX).unwrap();
+        black_box(out).len()
+    });
     runner.register("snap", move |i| {
         let out = black_box(compress_snap(i));
         out.len()

--- a/src/block/compress.rs
+++ b/src/block/compress.rs
@@ -74,7 +74,7 @@ fn token_from_literal(lit_len: usize) -> u8 {
 }
 
 #[inline]
-fn token_from_literal_and_match_length(lit_len: usize, duplicate_length: usize) -> u8 {
+pub(super) fn token_from_literal_and_match_length(lit_len: usize, duplicate_length: usize) -> u8 {
     let mut token = if lit_len < 0xF {
         // Since we can fit the literals length into it, there is no need for saturation.
         (lit_len as u8) << 4
@@ -490,13 +490,13 @@ pub(crate) fn compress_internal<T: HashTable, const USE_DICT: bool, S: Sink>(
 
 #[inline]
 #[cfg(feature = "safe-encode")]
-fn push_byte(output: &mut impl Sink, el: u8) {
+pub(super) fn push_byte(output: &mut impl Sink, el: u8) {
     output.push(el);
 }
 
 #[inline]
 #[cfg(not(feature = "safe-encode"))]
-fn push_byte(output: &mut impl Sink, el: u8) {
+pub(super) fn push_byte(output: &mut impl Sink, el: u8) {
     unsafe {
         core::ptr::write(output.pos_mut_ptr(), el);
         output.set_pos(output.pos() + 1);
@@ -505,13 +505,13 @@ fn push_byte(output: &mut impl Sink, el: u8) {
 
 #[inline]
 #[cfg(feature = "safe-encode")]
-fn push_u16(output: &mut impl Sink, el: u16) {
+pub(super) fn push_u16(output: &mut impl Sink, el: u16) {
     output.extend_from_slice(&el.to_le_bytes());
 }
 
 #[inline]
 #[cfg(not(feature = "safe-encode"))]
-fn push_u16(output: &mut impl Sink, el: u16) {
+pub(super) fn push_u16(output: &mut impl Sink, el: u16) {
     unsafe {
         core::ptr::copy_nonoverlapping(el.to_le_bytes().as_ptr(), output.pos_mut_ptr(), 2);
         output.set_pos(output.pos() + 2);

--- a/src/block/mod.rs
+++ b/src/block/mod.rs
@@ -27,8 +27,96 @@ pub(crate) use decompress_safe as decompress;
 #[cfg(not(feature = "safe-decode"))]
 pub(crate) mod decompress;
 
+#[cfg(feature = "ultra")]
+#[cfg_attr(feature = "safe-encode", forbid(unsafe_code))]
+pub(crate) mod ultra;
+
 pub use compress::*;
 pub use decompress::*;
+
+/// Selects which compressor the `compress_*_with_mode` entry points (and the
+/// [frame encoder][crate::frame::FrameEncoder::set_compression_mode]) use.
+///
+/// [`Fast`](Self::Fast) is the default greedy/lazy compressor (exactly [`compress`]); the other two
+/// are optimal-parse "ultra" engines that compress better at the cost of speed/memory.
+#[cfg(feature = "ultra")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ultra")))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CompressionMode {
+    /// Fast greedy/lazy compressor — identical to [`compress`]. The default.
+    #[default]
+    Fast,
+    /// Optimal-parse suffix-array compressor. Best ratio and a decode-optimised stream (favours
+    /// decompression speed), but the slowest and most memory-hungry.
+    Ultra,
+    /// Hash-chain optimal compressor (matches `lz4hc -12`): ratio close to [`Ultra`](Self::Ultra),
+    /// several times faster, far less memory.
+    Hc,
+}
+
+#[cfg(feature = "ultra")]
+impl CompressionMode {
+    /// `(favor, finder)` for the optimal-parse engines; `None` for [`Fast`](Self::Fast).
+    #[inline]
+    pub(crate) fn ultra_engine(self) -> Option<(ultra::Favor, ultra::Finder)> {
+        match self {
+            CompressionMode::Fast => None,
+            CompressionMode::Ultra => {
+                Some((ultra::Favor::DecompressionSpeed, ultra::Finder::SuffixArray))
+            }
+            CompressionMode::Hc => Some((ultra::Favor::Ratio, ultra::Finder::Lz4Hc)),
+        }
+    }
+}
+
+/// Compress `input` with the chosen [`CompressionMode`], optionally using `dict` for lookback
+/// (pass `b""` for none). With [`CompressionMode::Fast`] this is exactly [`compress`] /
+/// [`compress_with_dict`]. The result is a standard LZ4 block decodable by [`decompress`].
+#[cfg(feature = "ultra")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ultra")))]
+pub fn compress_with_mode(input: &[u8], dict: &[u8], mode: CompressionMode) -> alloc::vec::Vec<u8> {
+    match mode.ultra_engine() {
+        None if dict.is_empty() => compress(input),
+        None => compress_with_dict(input, dict),
+        Some((favor, finder)) => ultra::compress_into_vec(input, false, dict, favor, finder),
+    }
+}
+
+/// Like [`compress_with_mode`], prepending the uncompressed size as a little-endian `u32` (pairs
+/// with [`decompress_size_prepended`] / [`decompress_size_prepended_with_dict`]).
+#[cfg(feature = "ultra")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ultra")))]
+pub fn compress_prepend_size_with_mode(
+    input: &[u8],
+    dict: &[u8],
+    mode: CompressionMode,
+) -> alloc::vec::Vec<u8> {
+    match mode.ultra_engine() {
+        None if dict.is_empty() => compress_prepend_size(input),
+        None => compress_prepend_size_with_dict(input, dict),
+        Some((favor, finder)) => ultra::compress_into_vec(input, true, dict, favor, finder),
+    }
+}
+
+/// Like [`compress_with_mode`], writing into the pre-allocated `output` (size it with
+/// [`get_maximum_output_size`]). Returns the number of bytes written.
+#[cfg(feature = "ultra")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ultra")))]
+pub fn compress_into_with_mode(
+    input: &[u8],
+    output: &mut [u8],
+    dict: &[u8],
+    mode: CompressionMode,
+) -> Result<usize, CompressError> {
+    match mode.ultra_engine() {
+        None if dict.is_empty() => compress_into(input, output),
+        None => compress_into_with_dict(input, output, dict),
+        Some((favor, finder)) => {
+            let mut sink = crate::sink::SliceSink::new(output, 0);
+            ultra::compress_one_shot(input, dict, favor, finder, &mut sink)
+        }
+    }
+}
 
 use core::{error::Error, fmt};
 

--- a/src/block/ultra/lz4hc.rs
+++ b/src/block/ultra/lz4hc.rs
@@ -1,0 +1,548 @@
+//! A fast optimal-parse compressor: a hash-chain match finder feeding a price-based dynamic program.
+//! It emits a standard LZ4 block directly, runs several times faster than the suffix-array path at a
+//! comparable ratio, and is what [`super::CompressionMode::Hc`] selects. Output matches `lz4hc -12`.
+//!
+//! We only ever search a single contiguous window (callers fold a dictionary in as a prefix) and
+//! always from the current position forwards, so there's no external-dictionary or backward-match
+//! handling here. Long runs are kept fast by stopping as soon as a maximal-length match is found
+//! (it's already optimal); general repetitive data relies on the chain-swap step below.
+
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::block::compress::{
+    push_byte, push_u16, token_from_literal_and_match_length, write_integer,
+};
+use crate::block::{CompressError, LAST_LITERALS, MFLIMIT};
+use crate::sink::Sink;
+
+use super::MIN_MATCH_SIZE;
+
+const HASH_LOG: u32 = 15;
+const HASH_SIZE: usize = 1 << HASH_LOG; // 32768
+const CHAIN_SIZE: usize = 1 << 16; // 65536, indexed by (pos as u16)
+const BASE: u32 = 1 << 16; // index offset so an empty hash slot (0) reads as "too far"
+const DISTANCE_MAX: u32 = crate::block::MAX_DISTANCE as u32;
+
+const LZ4_OPT_NUM: usize = 1 << 12; // 4096
+const TRAILING_LITERALS: usize = 3;
+const OPT_SIZE: usize = LZ4_OPT_NUM + TRAILING_LITERALS;
+
+// Max-effort search depth and the match length past which we stop looking for a better one.
+const NB_SEARCHES: i32 = 16384;
+const SUFFICIENT_LEN: i32 = (LZ4_OPT_NUM - 1) as i32;
+
+#[inline]
+fn read16(w: &[u8], i: usize) -> u16 {
+    u16::from_le_bytes([w[i], w[i + 1]])
+}
+#[inline]
+fn read32(w: &[u8], i: usize) -> u32 {
+    // Native-endian. Only used for hashing and equality checks, so endianness doesn't affect the
+    // result.
+    crate::block::compress::get_batch(w, i)
+}
+#[inline]
+fn read64(w: &[u8], i: usize) -> u64 {
+    u64::from_le_bytes(w[i..i + 8].try_into().unwrap())
+}
+#[inline]
+fn hash4(w: &[u8], i: usize) -> usize {
+    (read32(w, i).wrapping_mul(2_654_435_761) >> (32 - HASH_LOG)) as usize
+}
+
+/// Common-prefix length of `w[a..]` and `w[b..]`, where `a` (the "in" side) may not reach `a_limit`.
+#[inline]
+fn count(w: &[u8], mut a: usize, mut b: usize, a_limit: usize) -> usize {
+    let start = a;
+    while a + 8 <= a_limit {
+        let d = read64(w, a) ^ read64(w, b);
+        if d != 0 {
+            return a - start + (d.trailing_zeros() / 8) as usize;
+        }
+        a += 8;
+        b += 8;
+    }
+    while a < a_limit && w[a] == w[b] {
+        a += 1;
+        b += 1;
+    }
+    a - start
+}
+
+#[derive(Clone, Copy)]
+struct Opt {
+    price: i32,
+    off: i32,
+    mlen: i32,
+    litlen: i32,
+}
+
+/// Reusable hash-chain compressor state.
+pub(crate) struct HcCompressor {
+    hash: Box<[u32; HASH_SIZE]>,
+    chain: Box<[u16; CHAIN_SIZE]>,
+    opt: Vec<Opt>,
+}
+
+#[inline]
+fn literals_price(litlen: i32) -> i32 {
+    litlen + super::varlen_extra_bytes(litlen as usize) as i32
+}
+
+#[inline]
+fn sequence_price(litlen: i32, mlen: i32) -> i32 {
+    // token + 16-bit offset + literals + the match length's varlen bytes (encoded = mlen - MIN_MATCH_SIZE).
+    1 + 2
+        + literals_price(litlen)
+        + super::varlen_extra_bytes((mlen - MIN_MATCH_SIZE) as usize) as i32
+}
+
+impl HcCompressor {
+    pub(crate) fn new() -> Self {
+        let hash: Box<[u32; HASH_SIZE]> =
+            vec![0u32; HASH_SIZE].into_boxed_slice().try_into().unwrap();
+        let chain: Box<[u16; CHAIN_SIZE]> = vec![0xFFFFu16; CHAIN_SIZE]
+            .into_boxed_slice()
+            .try_into()
+            .unwrap();
+        HcCompressor {
+            hash,
+            chain,
+            opt: Vec::new(),
+        }
+    }
+
+    fn reset(&mut self) {
+        self.hash.fill(0);
+        self.chain.fill(0xFFFF);
+        if self.opt.len() != OPT_SIZE {
+            self.opt = vec![
+                Opt {
+                    price: 0,
+                    off: 0,
+                    mlen: 0,
+                    litlen: 0
+                };
+                OPT_SIZE
+            ];
+        }
+    }
+
+    /// Insert hash-chain entries for all positions in `[next..target)` (positions are absolute
+    /// indices = window offset + BASE). `next_to_update` tracks how far we've inserted.
+    #[inline]
+    fn insert(&mut self, w: &[u8], next_to_update: &mut u32, target_idx: u32) {
+        let mut idx = *next_to_update;
+        while idx < target_idx {
+            let pos = (idx - BASE) as usize;
+            let h = hash4(w, pos);
+            let mut delta = idx - self.hash[h];
+            if delta > DISTANCE_MAX {
+                delta = DISTANCE_MAX;
+            }
+            self.chain[idx as u16 as usize] = delta as u16;
+            self.hash[h] = idx;
+            idx += 1;
+        }
+        *next_to_update = target_idx;
+    }
+
+    /// Find the longest match at `ip_pos`, returning `(length, offset)` with `length <= min_len`
+    /// meaning "no better match". `matchlimit = n - LAST_LITERALS`.
+    fn find_match(
+        &mut self,
+        w: &[u8],
+        next_to_update: &mut u32,
+        ip_pos: usize,
+        min_len: i32,
+        matchlimit: usize,
+        favor_dec_speed: bool,
+    ) -> (i32, i32) {
+        let ip_index = ip_pos as u32 + BASE;
+        let lowest = if BASE + DISTANCE_MAX + 1 > ip_index {
+            BASE
+        } else {
+            ip_index - DISTANCE_MAX
+        };
+        let pattern = read32(w, ip_pos);
+        let mut longest = min_len;
+        let mut offset = 0i32;
+        let mut match_chain_pos: u32 = 0;
+        let max_possible = (matchlimit - ip_pos) as i32;
+
+        self.insert(w, next_to_update, ip_index);
+        let mut match_index = self.hash[hash4(w, ip_pos)];
+        let mut nb = NB_SEARCHES;
+
+        while match_index >= lowest && nb > 0 {
+            nb -= 1;
+            let mut match_length = 0i32;
+            let m_pos = (match_index - BASE) as usize;
+
+            // When favouring decompression speed, skip matches with offset < 8: such matches force
+            // the decoder's slow overlapping-copy path, so trading them away speeds decompression.
+            // 2-byte filter at `longest-1`, then confirm 4-byte pattern.
+            if !(favor_dec_speed && ip_index - match_index < 8)
+                && read16(w, ip_pos + longest as usize - 1)
+                    == read16(w, m_pos + longest as usize - 1)
+                && read32(w, m_pos) == pattern
+            {
+                match_length = MIN_MATCH_SIZE + count(w, ip_pos + 4, m_pos + 4, matchlimit) as i32;
+                if match_length > longest {
+                    longest = match_length;
+                    offset = (ip_index - match_index) as i32;
+                    if longest >= max_possible {
+                        break; // maximal match — already optimal (handles runs)
+                    }
+                }
+            }
+
+            // chain-swap: when a candidate ties the current best, jump along the match to the chain
+            // link with the largest stride, skipping redundant inside-match candidates.
+            if match_length == longest && match_index + longest as u32 <= ip_index {
+                const K_TRIGGER: i32 = 4;
+                let mut dist_to_next_match: u32 = 1;
+                let end = longest - MIN_MATCH_SIZE + 1;
+                let mut accel = 1i32 << K_TRIGGER;
+                let mut pos = 0i32;
+                while pos < end {
+                    let candidate_dist =
+                        self.chain[(match_index + pos as u32) as u16 as usize] as u32;
+                    let step = accel >> K_TRIGGER;
+                    accel += 1;
+                    if candidate_dist > dist_to_next_match {
+                        dist_to_next_match = candidate_dist;
+                        match_chain_pos = pos as u32;
+                        accel = 1 << K_TRIGGER;
+                    }
+                    pos += step;
+                }
+                if dist_to_next_match > 1 {
+                    if dist_to_next_match > match_index {
+                        break; // avoid overflow
+                    }
+                    match_index -= dist_to_next_match;
+                    continue;
+                }
+            }
+
+            match_index -= self.chain[(match_index + match_chain_pos) as u16 as usize] as u32;
+        }
+
+        (longest, offset)
+    }
+
+    /// Returns `(0,0)` unless there's a match strictly longer than `min_len`.
+    #[inline]
+    fn find_longer_match(
+        &mut self,
+        w: &[u8],
+        next_to_update: &mut u32,
+        ip_pos: usize,
+        min_len: i32,
+        matchlimit: usize,
+        favor_dec_speed: bool,
+    ) -> (i32, i32) {
+        let (len, off) = self.find_match(
+            w,
+            next_to_update,
+            ip_pos,
+            min_len,
+            matchlimit,
+            favor_dec_speed,
+        );
+        if len <= min_len {
+            return (0, 0);
+        }
+        // When favouring decompression speed, a match just over the fast-path threshold is shortened
+        // back to 18 so the decoder stays on its branchless fast copy.
+        if favor_dec_speed && len > 18 && len <= 36 {
+            return (18, off);
+        }
+        (len, off)
+    }
+
+    /// Optimally compress `w[prefix_len..]` (using `w[..prefix_len]` as lookback) into `out`,
+    /// emitting a standard LZ4 block. `favor_dec_speed` trades a little ratio for a decode-optimised
+    /// stream. Returns the number of bytes written.
+    pub(crate) fn compress(
+        &mut self,
+        w: &[u8],
+        prefix_len: usize,
+        favor_dec_speed: bool,
+        out: &mut impl Sink,
+    ) -> Result<usize, CompressError> {
+        let n = w.len();
+        let start_op = out.pos();
+        self.reset();
+        let mut next_to_update = BASE;
+
+        let mut ip = prefix_len;
+        let mut anchor = prefix_len; // start of the pending literal run
+
+        if n > MFLIMIT {
+            let mflimit = n - MFLIMIT; // last position a match may start at (inclusive: ip <= mflimit)
+            let matchlimit = n - LAST_LITERALS;
+
+            while ip <= mflimit {
+                let llen = (ip - anchor) as i32;
+                let (first_len, first_off) = self.find_longer_match(
+                    w,
+                    &mut next_to_update,
+                    ip,
+                    MIN_MATCH_SIZE - 1,
+                    matchlimit,
+                    favor_dec_speed,
+                );
+                if first_len == 0 {
+                    ip += 1;
+                    continue;
+                }
+
+                if first_len > SUFFICIENT_LEN {
+                    self.encode_sequence(out, w, &mut ip, &mut anchor, first_len, first_off)?;
+                    continue;
+                }
+
+                let mut last_match_pos = first_len as usize;
+                let best_mlen;
+                let best_off;
+
+                for r_pos in 0..MIN_MATCH_SIZE as usize {
+                    let cost = literals_price(llen + r_pos as i32);
+                    self.opt[r_pos] = Opt {
+                        mlen: 1,
+                        off: 0,
+                        litlen: llen + r_pos as i32,
+                        price: cost,
+                    };
+                }
+                for mlen in MIN_MATCH_SIZE as usize..=first_len as usize {
+                    let cost = sequence_price(llen, mlen as i32);
+                    self.opt[mlen] = Opt {
+                        mlen: mlen as i32,
+                        off: first_off,
+                        litlen: llen,
+                        price: cost,
+                    };
+                }
+                for add_lit in 1..=TRAILING_LITERALS {
+                    self.opt[last_match_pos + add_lit] = Opt {
+                        mlen: 1,
+                        off: 0,
+                        litlen: add_lit as i32,
+                        price: self.opt[last_match_pos].price + literals_price(add_lit as i32),
+                    };
+                }
+
+                let mut cur = 1usize;
+                let mut goto_encode = false;
+                let mut imm_best_mlen = 0i32;
+                let mut imm_best_off = 0i32;
+                let mut imm_last_match_pos = 0usize;
+
+                while cur < last_match_pos {
+                    let cur_ptr = ip + cur;
+                    if cur_ptr > mflimit {
+                        break;
+                    }
+                    // skip test: this position can't improve on the path so far
+                    if self.opt[cur + 1].price <= self.opt[cur].price
+                        && self.opt[cur + MIN_MATCH_SIZE as usize].price < self.opt[cur].price + 3
+                    {
+                        cur += 1;
+                        continue;
+                    }
+
+                    let (new_len, new_off) = self.find_longer_match(
+                        w,
+                        &mut next_to_update,
+                        cur_ptr,
+                        MIN_MATCH_SIZE - 1,
+                        matchlimit,
+                        favor_dec_speed,
+                    );
+                    if new_len == 0 {
+                        cur += 1;
+                        continue;
+                    }
+
+                    if new_len > SUFFICIENT_LEN || new_len as usize + cur >= LZ4_OPT_NUM {
+                        imm_best_mlen = new_len;
+                        imm_best_off = new_off;
+                        imm_last_match_pos = cur + 1;
+                        goto_encode = true;
+                        break;
+                    }
+
+                    let base_litlen = self.opt[cur].litlen;
+                    for litlen in 1..MIN_MATCH_SIZE as usize {
+                        let price = self.opt[cur].price - literals_price(base_litlen)
+                            + literals_price(base_litlen + litlen as i32);
+                        let pos = cur + litlen;
+                        if price < self.opt[pos].price {
+                            self.opt[pos] = Opt {
+                                mlen: 1,
+                                off: 0,
+                                litlen: base_litlen + litlen as i32,
+                                price,
+                            };
+                        }
+                    }
+
+                    let match_ml = new_len;
+                    for ml in MIN_MATCH_SIZE..=match_ml {
+                        let pos = cur + ml as usize;
+                        let (ll, price);
+                        if self.opt[cur].mlen == 1 {
+                            ll = self.opt[cur].litlen;
+                            let base = if cur > ll as usize {
+                                self.opt[cur - ll as usize].price
+                            } else {
+                                0
+                            };
+                            price = base + sequence_price(ll, ml);
+                        } else {
+                            ll = 0;
+                            price = self.opt[cur].price + sequence_price(0, ml);
+                        }
+                        let favor_bias = favor_dec_speed as i32;
+                        if pos > last_match_pos + TRAILING_LITERALS
+                            || price <= self.opt[pos].price - favor_bias
+                        {
+                            if ml == match_ml && last_match_pos < pos {
+                                last_match_pos = pos;
+                            }
+                            self.opt[pos] = Opt {
+                                mlen: ml,
+                                off: new_off,
+                                litlen: ll,
+                                price,
+                            };
+                        }
+                    }
+                    for add_lit in 1..=TRAILING_LITERALS {
+                        self.opt[last_match_pos + add_lit] = Opt {
+                            mlen: 1,
+                            off: 0,
+                            litlen: add_lit as i32,
+                            price: self.opt[last_match_pos].price + literals_price(add_lit as i32),
+                        };
+                    }
+                    cur += 1;
+                }
+
+                // `cur_back` is where the reverse traversal starts. For an immediate encode it is the
+                // loop position `cur` (the match is recorded there); otherwise it is the start of the
+                // final match, `last_match_pos - best_mlen`.
+                let cur_back;
+                if goto_encode {
+                    best_mlen = imm_best_mlen;
+                    best_off = imm_best_off;
+                    last_match_pos = imm_last_match_pos;
+                    cur_back = cur as i32;
+                } else {
+                    best_mlen = self.opt[last_match_pos].mlen;
+                    best_off = self.opt[last_match_pos].off;
+                    cur_back = last_match_pos as i32 - best_mlen;
+                }
+
+                // reverse traversal to recover the shortest path
+                {
+                    let mut candidate_pos = cur_back;
+                    let mut selected_matchlength = best_mlen;
+                    let mut selected_offset = best_off;
+                    loop {
+                        let next_matchlength = self.opt[candidate_pos as usize].mlen;
+                        let next_offset = self.opt[candidate_pos as usize].off;
+                        self.opt[candidate_pos as usize].mlen = selected_matchlength;
+                        self.opt[candidate_pos as usize].off = selected_offset;
+                        selected_matchlength = next_matchlength;
+                        selected_offset = next_offset;
+                        if next_matchlength > candidate_pos {
+                            break;
+                        }
+                        candidate_pos -= next_matchlength;
+                    }
+                }
+
+                let mut r_pos = 0usize;
+                while r_pos < last_match_pos {
+                    let ml = self.opt[r_pos].mlen;
+                    let off = self.opt[r_pos].off;
+                    if ml == 1 {
+                        ip += 1;
+                        r_pos += 1;
+                        continue;
+                    }
+                    r_pos += ml as usize;
+                    self.encode_sequence(out, w, &mut ip, &mut anchor, ml, off)?;
+                }
+            }
+        }
+
+        self.encode_last_literals(out, w, anchor, n)?;
+        Ok(out.pos() - start_op)
+    }
+
+    /// Emit one (literals, match) sequence and advance `ip`/`anchor`.
+    #[inline]
+    fn encode_sequence(
+        &self,
+        out: &mut impl Sink,
+        w: &[u8],
+        ip: &mut usize,
+        anchor: &mut usize,
+        match_length: i32,
+        offset: i32,
+    ) -> Result<(), CompressError> {
+        let lit_len = *ip - *anchor;
+        let ml_code = (match_length - MIN_MATCH_SIZE) as usize;
+
+        let bytes = 1
+            + super::varlen_extra_bytes(lit_len)
+            + lit_len
+            + 2
+            + super::varlen_extra_bytes(ml_code);
+        if out.pos() + bytes > out.capacity() {
+            return Err(CompressError::OutputTooSmall);
+        }
+
+        push_byte(out, token_from_literal_and_match_length(lit_len, ml_code));
+        if lit_len >= 15 {
+            write_integer(out, lit_len - 15);
+        }
+        out.extend_from_slice(&w[*anchor..*anchor + lit_len]);
+        push_u16(out, offset as u16);
+        if ml_code >= 15 {
+            write_integer(out, ml_code - 15);
+        }
+
+        *ip += match_length as usize;
+        *anchor = *ip;
+        Ok(())
+    }
+
+    #[inline]
+    fn encode_last_literals(
+        &self,
+        out: &mut impl Sink,
+        w: &[u8],
+        anchor: usize,
+        n: usize,
+    ) -> Result<(), CompressError> {
+        let lit_len = n - anchor;
+        let bytes = 1 + super::varlen_extra_bytes(lit_len) + lit_len;
+        if out.pos() + bytes > out.capacity() {
+            return Err(CompressError::OutputTooSmall);
+        }
+        push_byte(out, token_from_literal_and_match_length(lit_len, 0));
+        if lit_len >= 15 {
+            write_integer(out, lit_len - 15);
+        }
+        out.extend_from_slice(&w[anchor..n]);
+        Ok(())
+    }
+}

--- a/src/block/ultra/matchfinder.rs
+++ b/src/block/ultra/matchfinder.rs
@@ -1,0 +1,286 @@
+//! LCP-interval match finder.
+//!
+//! For every position in the input it finds the single longest match (and a back-offset achieving
+//! it). It works off a suffix array (built in [`super::sais`]) plus an LCP array, organised into
+//! "LCP intervals". Because any prefix of a match at offset `D` is itself a match at offset `D`,
+//! storing just the longest match per position (together with its offset) is enough for the optimal
+//! parser to consider every useful sub-length.
+//!
+//! The 64-bit interval word gives positions a full 32 bits; the LCP field and visited flag are
+//! shifted up accordingly.
+
+// Index-arithmetic loops; iterator rewrites would obscure the algorithm.
+#![allow(clippy::needless_range_loop)]
+
+use alloc::vec::Vec;
+
+use super::sais::build_suffix_array;
+use super::{Match, LAST_LITERALS, LAST_MATCH_OFFSET, MAX_OFFSET, MIN_MATCH_SIZE};
+
+const LCP_BITS: u32 = 15;
+/// Match lengths are clamped to this (`1 << (LCP_BITS - 1)`).
+pub(super) const LCP_MAX: i32 = 1 << (LCP_BITS - 1); // 16384
+
+const LCP_SHIFT: u32 = 32;
+const POS_MASK: u64 = (1u64 << LCP_SHIFT) - 1; // bits [0, 32)
+const LCP_MASK: u64 = ((1u64 << LCP_BITS) - 1) << LCP_SHIFT; // bits [32, 47)
+const VISITED_FLAG: u64 = 1u64 << (LCP_SHIFT + LCP_BITS); // bit 47
+const EXCL_VISITED_MASK: u64 = VISITED_FLAG - 1; // bits [0, 47)
+
+/// Scratch buffers for the match finder, reused across blocks to avoid reallocation.
+pub(super) struct MatchFinder {
+    /// LCP-interval linkage, and later visited markers (`pos | VISITED_FLAG`).
+    intervals: Vec<u64>,
+    /// Per text-position link into the interval tree.
+    pos_data: Vec<u64>,
+    /// Stack of currently-open intervals during interval construction.
+    open: Vec<u64>,
+    /// Permuted-LCP scratch (doubles as the Phi array while computing it).
+    phi: Vec<i32>,
+    /// (position, clamped LCP) packed per suffix-array rank, consumed by `build_intervals`.
+    sa_lcp: Vec<u64>,
+}
+
+impl MatchFinder {
+    pub(super) fn new() -> Self {
+        MatchFinder {
+            intervals: Vec::new(),
+            pos_data: Vec::new(),
+            open: Vec::new(),
+            phi: Vec::new(),
+            sa_lcp: Vec::new(),
+        }
+    }
+
+    fn reserve(&mut self, n: usize) {
+        self.intervals.clear();
+        self.intervals.resize(n, 0);
+        self.pos_data.clear();
+        self.pos_data.resize(n, 0);
+        self.phi.clear();
+        self.phi.resize(n, 0);
+        self.sa_lcp.clear();
+        self.sa_lcp.resize(n, 0);
+        // Open-interval stack holds strictly increasing clamped LCP values plus a base entry.
+        let cap = LCP_MAX as usize + 2;
+        self.open.clear();
+        self.open.resize(cap, 0);
+    }
+
+    /// Build the suffix array, LCP, and LCP-interval structures over `window`.
+    fn build(&mut self, window: &[u8]) {
+        let n = window.len();
+        self.reserve(n);
+
+        let sa = build_suffix_array(window); // length n
+
+        // Permuted-LCP: `plcp[i]` is the LCP of the suffix at text position `i` with its predecessor
+        // in suffix-array order. `phi` doubles as `plcp` in place. `phi`/`sa_lcp` are reused across
+        // blocks (resized in `reserve`).
+        let phi = &mut self.phi;
+        phi[sa[0] as usize] = -1;
+        for r in 1..n {
+            phi[sa[r] as usize] = sa[r - 1];
+        }
+        let mut cur_len = 0i32;
+        for i in 0..n {
+            let p = phi[i];
+            if p < 0 {
+                phi[i] = 0;
+                continue;
+            }
+            let p = p as usize;
+            let max_len = if i > p { n - i } else { n - p } as i32;
+            while cur_len < max_len && window[i + cur_len as usize] == window[p + cur_len as usize]
+            {
+                cur_len += 1;
+            }
+            phi[i] = cur_len;
+            if cur_len > 0 {
+                cur_len -= 1;
+            }
+        }
+
+        // Pack (position, clamped LCP) per suffix-array rank into the `sa_lcp` array.
+        let phi = &self.phi;
+        let sa_lcp = &mut self.sa_lcp;
+        sa_lcp[0] = (sa[0] as u64) & POS_MASK; // first rank has LCP 0
+        for r in 1..n {
+            let idx = sa[r] as usize;
+            let mut len = phi[idx];
+            if len < MIN_MATCH_SIZE {
+                len = 0;
+            }
+            if len > LCP_MAX {
+                len = LCP_MAX;
+            }
+            sa_lcp[r] = (idx as u64) | ((len as u64) << LCP_SHIFT);
+        }
+
+        self.build_intervals();
+    }
+
+    /// Build LCP intervals from the (position, LCP) array.
+    fn build_intervals(&mut self) {
+        let sa_lcp = &self.sa_lcp;
+        let n = sa_lcp.len();
+        let intervals = &mut self.intervals;
+        let pos_data = &mut self.pos_data;
+        let open = &mut self.open;
+
+        let mut top = 0usize;
+        open[0] = 0;
+        intervals[0] = 0;
+        let mut next_interval_idx: u64 = 1;
+        let mut prev_pos = sa_lcp[0] & POS_MASK;
+
+        for r in 1..n {
+            let next_pos = sa_lcp[r] & POS_MASK;
+            let next_lcp = sa_lcp[r] & LCP_MASK;
+            let top_lcp = open[top] & LCP_MASK;
+
+            if next_lcp == top_lcp {
+                // Continuing the deepest open interval.
+                pos_data[prev_pos as usize] = open[top];
+            } else if next_lcp > top_lcp {
+                // Opening a new interval.
+                top += 1;
+                open[top] = next_lcp | next_interval_idx;
+                next_interval_idx += 1;
+                pos_data[prev_pos as usize] = open[top];
+            } else {
+                // Closing the deepest open interval (possibly several).
+                pos_data[prev_pos as usize] = open[top];
+                loop {
+                    let closed_interval_idx = open[top] & POS_MASK;
+                    top -= 1;
+                    let superinterval_lcp = open[top] & LCP_MASK;
+
+                    if next_lcp == superinterval_lcp {
+                        intervals[closed_interval_idx as usize] = open[top];
+                        break;
+                    } else if next_lcp > superinterval_lcp {
+                        top += 1;
+                        open[top] = next_lcp | next_interval_idx;
+                        next_interval_idx += 1;
+                        intervals[closed_interval_idx as usize] = open[top];
+                        break;
+                    } else {
+                        intervals[closed_interval_idx as usize] = open[top];
+                    }
+                }
+            }
+            prev_pos = next_pos;
+        }
+
+        // Close any still-open intervals.
+        pos_data[prev_pos as usize] = open[top];
+        while top > 0 {
+            intervals[(open[top] & POS_MASK) as usize] = open[top - 1];
+            top -= 1;
+        }
+    }
+
+    /// Find matches at `n_offset`, storing up to `out.len()` of them (longest first). Always runs
+    /// the full interval traversal (its lazy updates are needed for later positions) even when
+    /// `out` is empty. Returns the number of matches stored.
+    fn find_matches_at(&mut self, n_offset: usize, out: &mut [Match]) -> usize {
+        let intervals = &mut self.intervals;
+        let pos_data = &mut self.pos_data;
+        let max_matches = out.len();
+
+        let mut r = pos_data[n_offset];
+        pos_data[n_offset] = 0;
+
+        // Ascend to a visited interval / the root, linking unvisited intervals to this suffix.
+        let mut super_ref;
+        loop {
+            super_ref = intervals[(r & POS_MASK) as usize];
+            if super_ref & LCP_MASK == 0 {
+                break;
+            }
+            intervals[(r & POS_MASK) as usize] = n_offset as u64 | VISITED_FLAG;
+            r = super_ref;
+        }
+
+        if super_ref == 0 {
+            if r != 0 {
+                intervals[(r & POS_MASK) as usize] = n_offset as u64 | VISITED_FLAG;
+            }
+            return 0;
+        }
+
+        let mut match_pos = super_ref & EXCL_VISITED_MASK;
+        let mut count = 0usize;
+        loop {
+            loop {
+                super_ref = pos_data[match_pos as usize];
+                if super_ref > r {
+                    match_pos = intervals[(super_ref & POS_MASK) as usize] & EXCL_VISITED_MASK;
+                } else {
+                    break;
+                }
+            }
+            intervals[(r & POS_MASK) as usize] = n_offset as u64 | VISITED_FLAG;
+            pos_data[match_pos as usize] = r;
+
+            if count < max_matches && match_pos < n_offset as u64 {
+                let offset = n_offset - match_pos as usize;
+                if offset <= MAX_OFFSET {
+                    out[count] = Match {
+                        length: (r >> LCP_SHIFT) as i32,
+                        offset: offset as u32,
+                    };
+                    count += 1;
+                }
+            }
+
+            if super_ref == 0 {
+                break;
+            }
+            r = super_ref;
+            match_pos = intervals[(r & POS_MASK) as usize] & EXCL_VISITED_MASK;
+        }
+
+        count
+    }
+
+    /// Find the longest match at every position in `window[prefix_len..]`, writing results into
+    /// `matches[prefix_len..]`. Positions in `window[..prefix_len]` are treated as already-compressed
+    /// lookback (their intervals are still traversed so the lazy updates stay consistent).
+    pub(super) fn find_all_matches(
+        &mut self,
+        window: &[u8],
+        prefix_len: usize,
+        matches: &mut [Match],
+    ) {
+        let n = window.len();
+        self.build(window);
+
+        // Skip the prefix: scan for side effects only, discard the matches.
+        for i in 0..prefix_len {
+            self.find_matches_at(i, &mut []);
+        }
+
+        let mut scratch = [Match {
+            length: 0,
+            offset: 0,
+        }];
+        for i in prefix_len..n {
+            let num = self.find_matches_at(i, &mut scratch);
+            if num == 0 || i > n - LAST_MATCH_OFFSET {
+                matches[i] = Match {
+                    length: 0,
+                    offset: 0,
+                };
+            } else {
+                let mut m = scratch[0];
+                let max_len = (n - LAST_LITERALS).saturating_sub(i) as i32;
+                if m.length > max_len {
+                    m.length = max_len;
+                }
+                matches[i] = m;
+            }
+        }
+    }
+}

--- a/src/block/ultra/mod.rs
+++ b/src/block/ultra/mod.rs
@@ -1,0 +1,209 @@
+//! Optimal-parse "ultra" LZ4 block compressor (feature `ultra`).
+//!
+//! Produces standard LZ4 blocks, identical in format to those written by
+//! [`crate::block::compress`], but uses an optimal parser instead of the fast greedy/lazy one for a
+//! better compression ratio.
+//!
+//! Two engines are available, selected via [`crate::block::CompressionMode`]:
+//! - [`Ultra`](crate::block::CompressionMode::Ultra) ([`Finder::SuffixArray`]): a suffix array
+//!   ([`sais`]) + LCP-interval match finder ([`matchfinder`]) feeding a backward dynamic-program
+//!   optimal parse ([`optimize`]). Finds the true longest match at every position and produces a
+//!   decode-optimised stream. The most thorough strategy but several times slower to compress and
+//!   uses ~`O(36 * input_len)` bytes; for bounded memory on large inputs prefer the
+//!   [frame API][crate::frame] with a fixed block size.
+//! - [`Hc`](crate::block::CompressionMode::Hc) ([`Finder::Lz4Hc`], [`lz4hc`]): a hash-chain match
+//!   finder with chain-swapping plus a price-based optimal parser. Ratio close to `Ultra`, several
+//!   times faster, far less memory.
+
+mod lz4hc;
+mod matchfinder;
+mod optimize;
+mod sais;
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::block::compress::get_maximum_output_size;
+use crate::block::{
+    CompressError, LAST_LITERALS, MAX_DISTANCE as MAX_OFFSET, MFLIMIT as LAST_MATCH_OFFSET,
+    WINDOW_SIZE,
+};
+use crate::sink::{Sink, SliceSink};
+
+use lz4hc::HcCompressor;
+use matchfinder::MatchFinder;
+
+const MIN_MATCH_SIZE: i32 = crate::block::MINMATCH as i32;
+/// Literal-length run value that triggers variable-length encoding (token nibble max).
+const LITERALS_RUN_LEN: i32 = 15;
+/// Match-length run value that triggers variable-length encoding (token nibble max).
+const MATCH_RUN_LEN: i32 = 15;
+/// Matches at least this long skip the per-sub-length cost search (kept whole) for speed.
+const LEAVE_ALONE_MATCH_SIZE: i32 = 1100;
+/// Cost (in bits) added when switching between literal and match runs, to break ties toward fewer
+/// mode switches.
+const MODESWITCH_PENALTY: i32 = 1;
+
+/// Number of extra variable-length-encoding bytes an encoded length needs. The token's 4-bit nibble
+/// holds up to the run value (15); anything larger spills into `(len - 15) / 255` continuation bytes
+/// of `0xFF` plus one final byte.
+pub(super) fn varlen_extra_bytes(encoded_len: usize) -> usize {
+    if encoded_len >= LITERALS_RUN_LEN as usize {
+        (encoded_len - LITERALS_RUN_LEN as usize) / 255 + 1
+    } else {
+        0
+    }
+}
+
+/// One match candidate: `length` of `0` means "emit a literal here" once the parse is chosen, and
+/// `-1` is the join marker used by the command-count optimiser. `offset` is the back-distance.
+#[derive(Clone, Copy)]
+struct Match {
+    pub length: i32,
+    pub offset: u32,
+}
+
+/// Whether the optimal parser should favour ratio or decompression speed when costs tie.
+#[derive(Clone, Copy)]
+pub(crate) enum Favor {
+    /// Best compression ratio.
+    Ratio,
+    /// Trade a little ratio for faster decompression.
+    DecompressionSpeed,
+}
+
+/// Which compression strategy to use.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Finder {
+    /// Suffix-array match finder + optimal-parse DP: always finds the true longest match at every
+    /// position. Robust and near-optimal, but slower and more memory-hungry.
+    SuffixArray,
+    /// Hash-chain match finder with chain-swapping plus a price-based optimal parser. Same ratio as
+    /// the suffix array on real data, several times faster.
+    Lz4Hc,
+}
+
+/// Reusable optimal-parse compressor context. Owns the per-block scratch buffers so that callers
+/// compressing many blocks (e.g. the frame encoder) don't reallocate each time.
+pub(crate) struct UltraCompressor {
+    sa_finder: MatchFinder,
+    // Lazily created on first use: its fixed 256 KB hash+chain arrays shouldn't be allocated for
+    // callers that only ever use the default suffix-array path.
+    hc: Option<HcCompressor>,
+    matches: Vec<Match>,
+    cost: Vec<i32>,
+    score: Vec<i32>,
+}
+
+impl UltraCompressor {
+    pub(crate) fn new() -> Self {
+        UltraCompressor {
+            sa_finder: MatchFinder::new(),
+            hc: None,
+            matches: Vec::new(),
+            cost: Vec::new(),
+            score: Vec::new(),
+        }
+    }
+
+    /// Optimally compress `window[prefix_len..]` into `out`, using `window[..prefix_len]` as
+    /// already-emitted lookback (a prefix and/or external dictionary). Returns the number of bytes
+    /// written. Offsets in the produced block are distances within `window`.
+    pub(crate) fn compress_block(
+        &mut self,
+        window: &[u8],
+        prefix_len: usize,
+        favor: Favor,
+        finder: Finder,
+        out: &mut impl Sink,
+    ) -> Result<usize, CompressError> {
+        if let Finder::Lz4Hc = finder {
+            let favor_dec_speed = matches!(favor, Favor::DecompressionSpeed);
+            return self.hc.get_or_insert_with(HcCompressor::new).compress(
+                window,
+                prefix_len,
+                favor_dec_speed,
+                out,
+            );
+        }
+
+        let n = window.len();
+        if n == 0 {
+            return optimize::write_block(window, 0, 0, &[], out);
+        }
+
+        let zero = Match {
+            length: 0,
+            offset: 0,
+        };
+        self.matches.clear();
+        self.matches.resize(n, zero);
+        self.cost.clear();
+        self.cost.resize(n, 0);
+        self.score.clear();
+        self.score.resize(n, 0);
+
+        self.sa_finder
+            .find_all_matches(window, prefix_len, &mut self.matches);
+        optimize::optimize_matches(
+            prefix_len,
+            n,
+            &mut self.matches,
+            &mut self.cost,
+            &mut self.score,
+            favor,
+        );
+        optimize::optimize_command_count(window, prefix_len, n, &mut self.matches);
+        optimize::write_block(window, prefix_len, n, &self.matches, out)
+    }
+}
+
+/// Optimally compress `input` (with optional `ext_dict` lookback) into `out` using the given
+/// engine. Shared by the block `compress_*_with_mode` entry points and the frame encoder.
+pub(crate) fn compress_one_shot(
+    input: &[u8],
+    ext_dict: &[u8],
+    favor: Favor,
+    finder: Finder,
+    out: &mut impl Sink,
+) -> Result<usize, CompressError> {
+    let mut comp = UltraCompressor::new();
+    // Only the last WINDOW_SIZE bytes of the dictionary are reachable (offsets are capped at 64 KiB);
+    // dropping the rest doesn't change the output and bounds the suffix-array size.
+    let dict = &ext_dict[ext_dict.len().saturating_sub(WINDOW_SIZE)..];
+    if dict.is_empty() {
+        comp.compress_block(input, 0, favor, finder, out)
+    } else {
+        let mut window = Vec::with_capacity(dict.len() + input.len());
+        window.extend_from_slice(dict);
+        window.extend_from_slice(input);
+        comp.compress_block(&window, dict.len(), favor, finder, out)
+    }
+}
+
+/// Optimally compress `input` into a freshly allocated `Vec` (optionally prepending the uncompressed
+/// size as a little-endian `u32`, and optionally with an external dictionary).
+pub(crate) fn compress_into_vec(
+    input: &[u8],
+    prepend_size: bool,
+    ext_dict: &[u8],
+    favor: Favor,
+    finder: Finder,
+) -> Vec<u8> {
+    let prepend = if prepend_size { 4 } else { 0 };
+    let max = get_maximum_output_size(input.len()) + prepend;
+    let mut buf = vec![0u8; max];
+    let written = {
+        let (header, body) = buf.split_at_mut(prepend);
+        if prepend_size {
+            header.copy_from_slice(&(input.len() as u32).to_le_bytes());
+        }
+        let mut sink = SliceSink::new(body, 0);
+        // The buffer is sized to `get_maximum_output_size`, which an optimal parse can never exceed
+        // (it never does worse than emitting all literals), so this cannot fail.
+        compress_one_shot(input, ext_dict, favor, finder, &mut sink)
+            .expect("output buffer large enough")
+    };
+    buf.truncate(prepend + written);
+    buf
+}

--- a/src/block/ultra/optimize.rs
+++ b/src/block/ultra/optimize.rs
@@ -1,0 +1,319 @@
+//! Optimal parse and block emission.
+//!
+//! Three passes over the per-position longest matches produced by [`super::matchfinder`]:
+//! 1. [`optimize_matches`] — a backward dynamic program choosing, for every position, whether to
+//!    emit a literal or a match (and at which length) to minimise the encoded size.
+//! 2. [`optimize_command_count`] — a forward pass that turns tiny matches back into literals and
+//!    joins adjacent equal-offset matches when it's free, reducing the command count (decompression
+//!    speed) without growing the output.
+//! 3. [`write_block`] — emits a standard LZ4 block, ending on a literals-only token.
+
+use crate::block::compress::{
+    push_byte, push_u16, token_from_literal_and_match_length, write_integer,
+};
+use crate::block::CompressError;
+use crate::sink::Sink;
+
+use super::{
+    Favor, Match, LAST_LITERALS, LEAVE_ALONE_MATCH_SIZE, LITERALS_RUN_LEN, MATCH_RUN_LEN,
+    MIN_MATCH_SIZE, MODESWITCH_PENALTY,
+};
+
+/// Extra *bits* to encode a literal run / match-code of `length` in the cost model — the byte cost
+/// (shared [`super::varlen_extra_bytes`]) scaled to bits. Lengths here are always `>= 0`.
+#[inline]
+fn varlen_bits(length: i32) -> i32 {
+    (super::varlen_extra_bytes(length as usize) as i32) << 3
+}
+
+/// Backward optimal parse. Rewrites `matches[start..end]` in place so that `matches[i].length` is
+/// either `0` (emit a literal at `i`) or the chosen match length (with `matches[i].offset` the
+/// offset to use). `cost`/`score` are scratch arrays of length `end`.
+pub(super) fn optimize_matches(
+    start: usize,
+    end: usize,
+    matches: &mut [Match],
+    cost: &mut [i32],
+    score: &mut [i32],
+    favor: Favor,
+) {
+    let extra_match_score: i32 = match favor {
+        Favor::Ratio => 1,
+        Favor::DecompressionSpeed => 5,
+    };
+
+    cost[end - 1] = 8;
+    score[end - 1] = 0;
+    let mut last_literals_offset = end;
+
+    // i from end-2 down to start (inclusive). Use isize so start == 0 terminates cleanly.
+    let mut ii = end as isize - 2;
+    while ii >= start as isize {
+        let i = ii as usize;
+
+        let literals_len = (last_literals_offset - i) as i32;
+        let mut best_cost = 8 + cost[i + 1];
+        let mut best_score = 1 + score[i + 1];
+        if literals_len >= LITERALS_RUN_LEN && (literals_len - LITERALS_RUN_LEN) % 255 == 0 {
+            // The literal run just crossed a variable-length encoding boundary.
+            best_cost += 8;
+        }
+        if matches[i + 1].length >= MIN_MATCH_SIZE {
+            best_cost += MODESWITCH_PENALTY;
+        }
+        let mut best_match_len: i32 = 0;
+        let mut best_match_offset: u32 = 0;
+
+        let cur_match = matches[i];
+        if cur_match.length >= MIN_MATCH_SIZE {
+            let offset = cur_match.offset;
+            // Cap the match so the last LAST_LITERALS bytes stay literals.
+            let mut match_len = cur_match.length;
+            if (i + match_len as usize) > (end - LAST_LITERALS) {
+                match_len = (end - LAST_LITERALS - i) as i32;
+            }
+
+            if cur_match.length >= LEAVE_ALONE_MATCH_SIZE {
+                let cur_cost = 8
+                    + 16
+                    + varlen_bits(match_len - MIN_MATCH_SIZE)
+                    + cost[i + match_len as usize]
+                    + if matches[i + match_len as usize].length >= MIN_MATCH_SIZE {
+                        MODESWITCH_PENALTY
+                    } else {
+                        0
+                    };
+                let cur_score = extra_match_score + score[i + match_len as usize];
+                if best_cost > cur_cost || (best_cost == cur_cost && best_score > cur_score) {
+                    best_cost = cur_cost;
+                    best_score = cur_score;
+                    best_match_len = match_len;
+                    best_match_offset = offset;
+                }
+            } else {
+                if let Favor::DecompressionSpeed = favor {
+                    // If the match is just above the fast-path threshold, shorten it back to the
+                    // threshold, trading a little ratio for decompression speed.
+                    if match_len > (MATCH_RUN_LEN + MIN_MATCH_SIZE - 1)
+                        && match_len <= 2 * (MATCH_RUN_LEN + MIN_MATCH_SIZE - 1)
+                    {
+                        match_len = MATCH_RUN_LEN + MIN_MATCH_SIZE - 1;
+                    }
+                }
+
+                let mut k = match_len;
+                while k >= MATCH_RUN_LEN + MIN_MATCH_SIZE {
+                    let cur_cost = 8
+                        + 16
+                        + varlen_bits(k - MIN_MATCH_SIZE)
+                        + cost[i + k as usize]
+                        + if matches[i + k as usize].length >= MIN_MATCH_SIZE {
+                            MODESWITCH_PENALTY
+                        } else {
+                            0
+                        };
+                    let cur_score = extra_match_score + score[i + k as usize];
+                    if best_cost > cur_cost || (best_cost == cur_cost && best_score > cur_score) {
+                        best_cost = cur_cost;
+                        best_score = cur_score;
+                        best_match_len = k;
+                        best_match_offset = offset;
+                    }
+                    k -= 1;
+                }
+                while k >= MIN_MATCH_SIZE {
+                    let cur_cost = 8 + 16 // no extra match-length bytes below MATCH_RUN_LEN
+                        + cost[i + k as usize]
+                        + if matches[i + k as usize].length >= MIN_MATCH_SIZE {
+                            MODESWITCH_PENALTY
+                        } else {
+                            0
+                        };
+                    let cur_score = extra_match_score + score[i + k as usize];
+                    if best_cost > cur_cost || (best_cost == cur_cost && best_score > cur_score) {
+                        best_cost = cur_cost;
+                        best_score = cur_score;
+                        best_match_len = k;
+                        best_match_offset = offset;
+                    }
+                    k -= 1;
+                }
+            }
+        }
+
+        if best_match_len >= MIN_MATCH_SIZE {
+            last_literals_offset = i;
+        }
+        cost[i] = best_cost;
+        score[i] = best_score;
+        matches[i].length = best_match_len;
+        matches[i].offset = best_match_offset;
+
+        ii -= 1;
+    }
+}
+
+/// Minimise the number of commands without growing the output.
+pub(super) fn optimize_command_count(
+    window: &[u8],
+    start: usize,
+    end: usize,
+    matches: &mut [Match],
+) {
+    let mut num_literals: i32 = 0;
+    let mut i = start;
+    while i < end {
+        let match_len = matches[i].length;
+        if match_len >= MIN_MATCH_SIZE {
+            let mut reduce = false;
+
+            if match_len <= 19 && (i + match_len as usize) < end {
+                let encoded = match_len - MIN_MATCH_SIZE;
+                let command_size = 8 + varlen_bits(num_literals) + 16 + varlen_bits(encoded);
+
+                if matches[i + match_len as usize].length >= MIN_MATCH_SIZE {
+                    // This match is followed by another match (no literals between). Re-encoding it
+                    // as literals can't grow the output and removes a command.
+                    if command_size >= (match_len << 3) + varlen_bits(num_literals + match_len) {
+                        reduce = true;
+                    }
+                } else {
+                    // This match is followed by some literals and then another match (or the end).
+                    let mut cur_index = i + match_len as usize;
+                    let mut next_num_literals: i32 = 0;
+                    loop {
+                        cur_index += 1;
+                        next_num_literals += 1;
+                        if !(cur_index < end && matches[cur_index].length < MIN_MATCH_SIZE) {
+                            break;
+                        }
+                    }
+                    if command_size
+                        >= (match_len << 3)
+                            + varlen_bits(num_literals + next_num_literals + match_len)
+                            - varlen_bits(next_num_literals)
+                    {
+                        reduce = true;
+                    }
+                }
+            }
+
+            if reduce {
+                for j in 0..match_len as usize {
+                    matches[i + j].length = 0;
+                }
+                num_literals += match_len;
+                i += match_len as usize;
+            } else {
+                // Try to join this match with the following one if they reproduce the same bytes.
+                let next = matches[i + match_len as usize];
+                let cur = matches[i];
+                if (i + match_len as usize) < end
+                    && cur.offset > 0
+                    && match_len >= 2
+                    && next.offset > 0
+                    && next.length >= 2
+                    && (match_len + next.length) >= LEAVE_ALONE_MATCH_SIZE
+                    && (match_len + next.length) <= 65535
+                    && (i + match_len as usize) >= cur.offset as usize
+                    && (i + match_len as usize) >= next.offset as usize
+                    && (i + match_len as usize + next.length as usize) <= end
+                {
+                    let base = i + match_len as usize;
+                    let a = base - cur.offset as usize;
+                    let b = base - next.offset as usize;
+                    let len = next.length as usize;
+                    if window[a..a + len] == window[b..b + len] {
+                        matches[i].length += next.length;
+                        matches[i + match_len as usize].offset = 0;
+                        matches[i + match_len as usize].length = -1;
+                        continue;
+                    }
+                }
+
+                num_literals = 0;
+                i += match_len as usize;
+            }
+        } else {
+            num_literals += 1;
+            i += 1;
+        }
+    }
+}
+
+/// Emit a standard LZ4 block for the optimally-parsed `matches[start..end]` into `out`.
+/// Returns the number of bytes written.
+pub(super) fn write_block(
+    window: &[u8],
+    start: usize,
+    end: usize,
+    matches: &[Match],
+    out: &mut impl Sink,
+) -> Result<usize, CompressError> {
+    let start_pos = out.pos();
+    let capacity = out.capacity();
+
+    let mut num_literals: usize = 0;
+    let mut first_literal_offset: usize = 0;
+
+    let mut i = start;
+    while i < end {
+        let m = matches[i];
+        if m.length >= MIN_MATCH_SIZE {
+            let match_offset = m.offset as usize;
+            let match_len = m.length as usize;
+            let encoded = (m.length - MIN_MATCH_SIZE) as usize;
+            debug_assert!((1..=super::MAX_OFFSET).contains(&match_offset));
+
+            let command_bytes = 1
+                + super::varlen_extra_bytes(num_literals)
+                + num_literals
+                + 2
+                + super::varlen_extra_bytes(encoded);
+            if out.pos() + command_bytes > capacity {
+                return Err(CompressError::OutputTooSmall);
+            }
+
+            push_byte(
+                out,
+                token_from_literal_and_match_length(num_literals, encoded),
+            );
+            if num_literals >= 15 {
+                write_integer(out, num_literals - 15);
+            }
+            if num_literals != 0 {
+                out.extend_from_slice(
+                    &window[first_literal_offset..first_literal_offset + num_literals],
+                );
+                num_literals = 0;
+            }
+            push_u16(out, match_offset as u16);
+            if encoded >= 15 {
+                write_integer(out, encoded - 15);
+            }
+
+            i += match_len;
+        } else {
+            if num_literals == 0 {
+                first_literal_offset = i;
+            }
+            num_literals += 1;
+            i += 1;
+        }
+    }
+
+    // Final literals-only command (match nibble 0, no offset).
+    let command_bytes = 1 + super::varlen_extra_bytes(num_literals) + num_literals;
+    if out.pos() + command_bytes > capacity {
+        return Err(CompressError::OutputTooSmall);
+    }
+    push_byte(out, token_from_literal_and_match_length(num_literals, 0));
+    if num_literals >= 15 {
+        write_integer(out, num_literals - 15);
+    }
+    if num_literals != 0 {
+        out.extend_from_slice(&window[first_literal_offset..first_literal_offset + num_literals]);
+    }
+
+    Ok(out.pos() - start_pos)
+}

--- a/src/block/ultra/sais.rs
+++ b/src/block/ultra/sais.rs
@@ -1,0 +1,287 @@
+//! Suffix array construction via the SA-IS algorithm.
+//!
+//! The choice of suffix-array algorithm does not affect the compressed output: the downstream
+//! LCP-interval match finder only depends on the order of the sorted suffixes and their
+//! longest-common-prefix lengths, both fully determined by the input. Suffixes that are a prefix of
+//! another sort first, because of the appended sentinel.
+//!
+//! Safe, O(n) Rust.
+
+// SA-IS is inherently index-arithmetic (type recurrences, induced sorting, bucket scans); rewriting
+// these loops as iterators would obscure the algorithm.
+#![allow(clippy::needless_range_loop)]
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+/// Build the suffix array of `input`.
+///
+/// Returns a `Vec<i32>` of length `input.len()` where `sa[r]` is the start position of the
+/// `r`-th smallest suffix. Suffixes are ordered as if an implicit end-of-string symbol smaller
+/// than every byte terminated the input (so a suffix that is a strict prefix of another sorts
+/// first).
+///
+/// # Panics
+/// Debug-asserts that `input.len() < i32::MAX`. Inputs at or above 2 GiB are not supported (the
+/// LZ4 block format caps match offsets at 64 KiB, so this is never a practical limitation).
+pub(crate) fn build_suffix_array(input: &[u8]) -> Vec<i32> {
+    debug_assert!(input.len() < i32::MAX as usize);
+    let n0 = input.len();
+    if n0 == 0 {
+        return Vec::new();
+    }
+    // Map bytes to 1..=256 and append a 0 sentinel that is strictly smaller than every real
+    // symbol. This makes the last position the unique smallest suffix, as SA-IS requires, and
+    // lets inputs that legitimately contain a 0 byte coexist with the sentinel.
+    let mut s: Vec<u32> = Vec::with_capacity(n0 + 1);
+    s.extend(input.iter().map(|&b| b as u32 + 1));
+    s.push(0);
+
+    let mut sa = vec![-1i32; n0 + 1];
+    sais(&s, &mut sa, 256);
+
+    // sa[0] is the sentinel suffix (position n0); drop it to return the n0 real suffixes.
+    debug_assert_eq!(sa[0], n0 as i32);
+    sa.split_off(1)
+}
+
+/// Histogram of the alphabet symbols in `s` (`counts[c]` = number of occurrences of symbol `c`).
+/// Computed once per recursion level; bucket boundaries are then derived from it in O(k) instead of
+/// rescanning `s` on every induced-sort pass.
+fn count_symbols(s: &[u32], k: usize) -> Vec<i32> {
+    let mut counts = vec![0i32; k + 1];
+    for &c in s {
+        counts[c as usize] += 1;
+    }
+    counts
+}
+
+/// Fill `bkt[0..=k]` with bucket boundaries derived from `counts`. With `end == true` each entry is
+/// the exclusive end of its bucket; with `end == false` each entry is the inclusive start (head).
+fn get_buckets(counts: &[i32], bkt: &mut [i32], end: bool) {
+    let mut sum = 0i32;
+    for (b, &c) in bkt.iter_mut().zip(counts.iter()) {
+        sum += c;
+        *b = if end { sum } else { sum - c };
+    }
+}
+
+/// Induced sort of the L-type suffixes (left-to-right scan, placing at bucket heads).
+fn induce_l(s: &[u32], sa: &mut [i32], t: &[bool], bkt: &mut [i32], counts: &[i32]) {
+    get_buckets(counts, bkt, false);
+    for i in 0..sa.len() {
+        let j = sa[i] - 1;
+        if j >= 0 && !t[j as usize] {
+            let c = s[j as usize] as usize;
+            sa[bkt[c] as usize] = j;
+            bkt[c] += 1;
+        }
+    }
+}
+
+/// Induced sort of the S-type suffixes (right-to-left scan, placing at bucket ends).
+fn induce_s(s: &[u32], sa: &mut [i32], t: &[bool], bkt: &mut [i32], counts: &[i32]) {
+    get_buckets(counts, bkt, true);
+    for i in (0..sa.len()).rev() {
+        let j = sa[i] - 1;
+        if j >= 0 && t[j as usize] {
+            let c = s[j as usize] as usize;
+            bkt[c] -= 1;
+            sa[bkt[c] as usize] = j;
+        }
+    }
+}
+
+/// Core recursive SA-IS. `s` is the string over alphabet `0..=k` (the last symbol must be the
+/// unique smallest), and the suffix array is written into `sa` (which must have length `s.len()`).
+fn sais(s: &[u32], sa: &mut [i32], k: usize) {
+    let n = s.len();
+    if n == 1 {
+        sa[0] = 0;
+        return;
+    }
+
+    // Classify each suffix as S-type (true) or L-type (false).
+    // S-type: s[i..] is lexicographically smaller than s[i+1..].
+    let mut t = vec![false; n];
+    t[n - 1] = true; // the sentinel suffix is S-type by definition
+    for i in (0..n - 1).rev() {
+        t[i] = s[i] < s[i + 1] || (s[i] == s[i + 1] && t[i + 1]);
+    }
+    let is_lms = |i: usize| -> bool { i > 0 && t[i] && !t[i - 1] };
+
+    let counts = count_symbols(s, k);
+    let mut bkt = vec![0i32; k + 1];
+
+    // Stage 1: place LMS suffixes at the ends of their buckets, then induce.
+    for x in sa.iter_mut() {
+        *x = -1;
+    }
+    get_buckets(&counts, &mut bkt, true);
+    for i in 1..n {
+        if is_lms(i) {
+            let c = s[i] as usize;
+            bkt[c] -= 1;
+            sa[bkt[c] as usize] = i as i32;
+        }
+    }
+    induce_l(s, sa, &t, &mut bkt, &counts);
+    induce_s(s, sa, &t, &mut bkt, &counts);
+
+    // Compact all sorted LMS positions into the front of `sa`.
+    let mut n1 = 0usize;
+    for i in 0..n {
+        if is_lms(sa[i] as usize) {
+            sa[n1] = sa[i];
+            n1 += 1;
+        }
+    }
+    // LMS positions are non-adjacent, so n1 <= n/2 <= n - n1: the name area below can't overlap.
+    for x in sa[n1..n].iter_mut() {
+        *x = -1;
+    }
+
+    // Name the LMS substrings: equal substrings get the same name.
+    let mut name = 0i32;
+    let mut prev: i32 = -1;
+    for i in 0..n1 {
+        let pos = sa[i] as usize;
+        let mut diff = false;
+        let mut d = 0usize;
+        loop {
+            if prev < 0 {
+                diff = true;
+                break;
+            }
+            let pp = prev as usize;
+            if s[pos + d] != s[pp + d] || t[pos + d] != t[pp + d] {
+                diff = true;
+                break;
+            }
+            if d > 0 && (is_lms(pos + d) || is_lms(pp + d)) {
+                // Reached the end of both LMS substrings without a difference: they're equal.
+                break;
+            }
+            d += 1;
+        }
+        if diff {
+            name += 1;
+            prev = pos as i32;
+        }
+        sa[n1 + pos / 2] = name - 1;
+    }
+    // Compact the names into the tail to form the reduced string.
+    let mut j = n - 1;
+    for i in (n1..n).rev() {
+        if sa[i] >= 0 {
+            sa[j] = sa[i];
+            j -= 1;
+        }
+    }
+
+    // Stage 2: solve the reduced problem.
+    let (left, s1) = sa.split_at_mut(n - n1); // s1 has length n1
+    if (name as usize) == n1 {
+        // Every LMS substring is unique: the suffix array is directly the inverse of the names.
+        for i in 0..n1 {
+            left[s1[i] as usize] = i as i32;
+        }
+    } else {
+        let reduced: Vec<u32> = s1.iter().map(|&x| x as u32).collect();
+        sais(&reduced, &mut left[..n1], (name - 1) as usize);
+    }
+
+    // Stage 3: induce the final suffix array from the sorted LMS suffixes.
+    // Recover the LMS positions in text order.
+    let mut p1: Vec<i32> = Vec::with_capacity(n1);
+    for i in 1..n {
+        if is_lms(i) {
+            p1.push(i as i32);
+        }
+    }
+    // Map the reduced-string suffix array back to original LMS positions.
+    for i in 0..n1 {
+        sa[i] = p1[sa[i] as usize];
+    }
+    for x in sa[n1..n].iter_mut() {
+        *x = -1;
+    }
+    // Place the sorted LMS suffixes at their bucket ends (reverse order), then induce.
+    get_buckets(&counts, &mut bkt, true);
+    for i in (0..n1).rev() {
+        let jpos = sa[i];
+        sa[i] = -1;
+        let c = s[jpos as usize] as usize;
+        bkt[c] -= 1;
+        sa[bkt[c] as usize] = jpos;
+    }
+    induce_l(s, sa, &t, &mut bkt, &counts);
+    induce_s(s, sa, &t, &mut bkt, &counts);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    /// Reference O(n^2 log n) suffix array for cross-checking.
+    fn naive_suffix_array(input: &[u8]) -> Vec<i32> {
+        let mut sa: Vec<i32> = (0..input.len() as i32).collect();
+        sa.sort_by(|&a, &b| input[a as usize..].cmp(&input[b as usize..]));
+        sa
+    }
+
+    fn check(input: &[u8]) {
+        let got = build_suffix_array(input);
+        let want = naive_suffix_array(input);
+        assert_eq!(got, want, "suffix array mismatch for input {input:?}");
+    }
+
+    #[test]
+    fn empty() {
+        assert!(build_suffix_array(b"").is_empty());
+    }
+
+    #[test]
+    fn single() {
+        check(b"a");
+        check(&[0u8]);
+        check(&[255u8]);
+    }
+
+    #[test]
+    fn classic_strings() {
+        check(b"banana");
+        check(b"mississippi");
+        check(b"abracadabra");
+        check(b"aaaaaa");
+        check(b"the quick brown fox jumps over the lazy dog");
+    }
+
+    #[test]
+    fn with_zero_bytes() {
+        check(&[0, 1, 0, 2, 0, 0, 1, 0]);
+        check(&[0, 0, 0, 0, 0]);
+        check(&[5, 0, 5, 0, 5]);
+    }
+
+    #[test]
+    fn pseudo_random() {
+        // Deterministic xorshift so the test is reproducible without rand.
+        let mut state: u64 = 0x9E3779B97F4A7C15;
+        let mut next = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        for &len in &[2usize, 3, 7, 16, 31, 64, 100, 257, 1000, 4096] {
+            for alphabet in &[2u8, 4, 16, 255] {
+                let data: Vec<u8> = (0..len)
+                    .map(|_| (next() % *alphabet as u64) as u8)
+                    .collect();
+                check(&data);
+            }
+        }
+    }
+}

--- a/src/frame/compress.rs
+++ b/src/frame/compress.rs
@@ -20,6 +20,12 @@ use super::{
 };
 use crate::block::WINDOW_SIZE;
 
+/// Selects the block compressor used by a [`FrameEncoder`] — the same enum as the block API's
+/// [`crate::block::CompressionMode`]. Purely a compressor-side choice; the frame format is unchanged,
+/// so streams produced with any mode are decodable by any LZ4 frame decoder.
+#[cfg(feature = "ultra")]
+pub use crate::block::CompressionMode;
+
 /// A writer for compressing a LZ4 stream.
 ///
 /// This `FrameEncoder` wraps any other writer that implements `io::Write`.
@@ -90,6 +96,17 @@ pub struct FrameEncoder<W: io::Write> {
     data_to_frame_written: bool,
     /// The frame information to be used in this encoder.
     frame_info: FrameInfo,
+    /// Which block compressor to use ([`CompressionMode::Fast`], [`Ultra`](CompressionMode::Ultra),
+    /// or [`Hc`](CompressionMode::Hc)).
+    #[cfg(feature = "ultra")]
+    ultra_mode: CompressionMode,
+    /// Reusable optimal-parse context, only used by the non-`Fast` modes.
+    #[cfg(feature = "ultra")]
+    ultra_compressor: crate::block::ultra::UltraCompressor,
+    /// Reusable buffer holding the contiguous lookback window (ext_dict ++ prefix ++ block) handed
+    /// to the ultra compressor in linked-block mode.
+    #[cfg(feature = "ultra")]
+    ultra_window: Vec<u8>,
 }
 
 impl<W: io::Write> FrameEncoder<W> {
@@ -149,12 +166,31 @@ impl<W: io::Write> FrameEncoder<W> {
             ext_dict_offset: 0,
             ext_dict_len: 0,
             src_stream_offset: 0,
+            #[cfg(feature = "ultra")]
+            ultra_mode: CompressionMode::Fast,
+            #[cfg(feature = "ultra")]
+            ultra_compressor: crate::block::ultra::UltraCompressor::new(),
+            #[cfg(feature = "ultra")]
+            ultra_window: Vec::new(),
         }
     }
 
     /// Creates a new Encoder with the default settings.
     pub fn new(wtr: W) -> Self {
         Self::with_frame_info(Default::default(), wtr)
+    }
+
+    /// Sets the block compressor used for this stream.
+    ///
+    /// Defaults to [`CompressionMode::Fast`]. [`Ultra`](CompressionMode::Ultra) (best ratio,
+    /// decode-optimised, slowest) and [`Hc`](CompressionMode::Hc) (fast, low memory, ratio close to
+    /// Ultra) use the optimal-parse compressor. The frame format is unchanged, so the output remains
+    /// decodable by any LZ4 frame decoder.
+    #[cfg(feature = "ultra")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "ultra")))]
+    pub fn set_compression_mode(&mut self, mode: CompressionMode) -> &mut Self {
+        self.ultra_mode = mode;
+        self
     }
 
     /// The frame information used by this Encoder.
@@ -263,46 +299,20 @@ impl<W: io::Write> FrameEncoder<W> {
         let max_block_size = self.frame_info.block_size.get_size();
         debug_assert!(self.src_end - self.src_start <= max_block_size);
 
-        // Reposition the compression table if we're anywhere near an overflowing hazard
-        if self.src_stream_offset + max_block_size + WINDOW_SIZE >= u32::MAX as usize / 2 {
-            self.compression_table
-                .reposition((self.src_stream_offset - self.ext_dict_len) as _);
-            self.src_stream_offset = self.ext_dict_len;
-        }
-
-        // input to the compressor, which may include a prefix when blocks are linked
-        let input = &self.src[..self.src_end];
         // the contents of the block are between src_start and src_end
-        let src = &input[self.src_start..];
+        let src_len = self.src_end - self.src_start;
 
-        let dst_required_size = crate::block::compress::get_maximum_output_size(src.len());
-
-        let compress_result = if self.ext_dict_len != 0 {
-            debug_assert_eq!(self.frame_info.block_mode, BlockMode::Linked);
-            compress_internal::<_, true, _>(
-                input,
-                self.src_start,
-                &mut vec_sink_for_compression(&mut self.dst, 0, 0, dst_required_size),
-                &mut self.compression_table,
-                &self.src[self.ext_dict_offset..self.ext_dict_offset + self.ext_dict_len],
-                self.src_stream_offset,
-            )
-        } else {
-            compress_internal::<_, false, _>(
-                input,
-                self.src_start,
-                &mut vec_sink_for_compression(&mut self.dst, 0, 0, dst_required_size),
-                &mut self.compression_table,
-                b"",
-                self.src_stream_offset,
-            )
-        };
+        // Compress the block into self.dst (fast or ultra path).
+        let compress_result = self.compress_current_block();
 
         let (block_info, block_data) = match compress_result.map_err(Error::CompressionError)? {
-            comp_len if comp_len < src.len() => {
+            comp_len if comp_len < src_len => {
                 (BlockInfo::Compressed(comp_len as _), &self.dst[..comp_len])
             }
-            _ => (BlockInfo::Uncompressed(src.len() as _), src),
+            _ => (
+                BlockInfo::Uncompressed(src_len as _),
+                &self.src[self.src_start..self.src_end],
+            ),
         };
 
         // Write the (un)compressed block to the writer and the block checksum (if applicable).
@@ -317,12 +327,13 @@ impl<W: io::Write> FrameEncoder<W> {
 
         // Content checksum, if applicable
         if self.frame_info.content_checksum {
-            self.content_hasher.write(src);
+            self.content_hasher
+                .write(&self.src[self.src_start..self.src_end]);
         }
 
         // Buffer and offsets maintenance
-        self.content_len += src.len() as u64;
-        self.src_start += src.len();
+        self.content_len += src_len as u64;
+        self.src_start += src_len;
         debug_assert_eq!(self.src_start, self.src_end);
         if self.frame_info.block_mode == BlockMode::Linked {
             // In linked mode we consume the input (bumping src_start) but leave the
@@ -363,11 +374,103 @@ impl<W: io::Write> FrameEncoder<W> {
             self.src_end = 0;
             // Advance stream offset so we don't have to reset the match dict
             // for the next block.
-            self.src_stream_offset += src.len();
+            self.src_stream_offset += src_len;
         }
         debug_assert!(self.src_start <= self.src_end);
         debug_assert!(self.src_start + max_block_size <= self.src.capacity());
         Ok(())
+    }
+
+    /// Compress the current block (`src[src_start..src_end]`, possibly with a prefix/ext_dict for
+    /// lookback) into `self.dst`, returning the compressed length. Dispatches to the fast or ultra
+    /// compressor.
+    fn compress_current_block(&mut self) -> Result<usize, crate::block::CompressError> {
+        #[cfg(feature = "ultra")]
+        if self.ultra_mode != CompressionMode::Fast {
+            return self.compress_current_block_ultra();
+        }
+
+        let max_block_size = self.frame_info.block_size.get_size();
+        // Reposition the compression table if we're anywhere near an overflowing hazard
+        if self.src_stream_offset + max_block_size + WINDOW_SIZE >= u32::MAX as usize / 2 {
+            self.compression_table
+                .reposition((self.src_stream_offset - self.ext_dict_len) as _);
+            self.src_stream_offset = self.ext_dict_len;
+        }
+
+        // input to the compressor, which may include a prefix when blocks are linked
+        let input = &self.src[..self.src_end];
+        let dst_required_size =
+            crate::block::compress::get_maximum_output_size(self.src_end - self.src_start);
+
+        if self.ext_dict_len != 0 {
+            debug_assert_eq!(self.frame_info.block_mode, BlockMode::Linked);
+            compress_internal::<_, true, _>(
+                input,
+                self.src_start,
+                &mut vec_sink_for_compression(&mut self.dst, 0, 0, dst_required_size),
+                &mut self.compression_table,
+                &self.src[self.ext_dict_offset..self.ext_dict_offset + self.ext_dict_len],
+                self.src_stream_offset,
+            )
+        } else {
+            compress_internal::<_, false, _>(
+                input,
+                self.src_start,
+                &mut vec_sink_for_compression(&mut self.dst, 0, 0, dst_required_size),
+                &mut self.compression_table,
+                b"",
+                self.src_stream_offset,
+            )
+        }
+    }
+
+    /// Optimal-parse ("ultra") compression of the current block into `self.dst`.
+    ///
+    /// Builds a single contiguous lookback window. In independent mode (and before the first linked
+    /// rotation) the encoder's `src` buffer already holds `prefix ++ block` contiguously, so it is
+    /// used directly. Once an external dictionary exists (linked mode after rotation), `ext_dict` and
+    /// `src[..src_end]` are concatenated into the reusable `ultra_window` buffer. Either way the
+    /// match offsets produced are true LZ4 back-distances, since the window bytes are exactly the
+    /// stream-contiguous predecessors the decoder holds.
+    #[cfg(feature = "ultra")]
+    fn compress_current_block_ultra(&mut self) -> Result<usize, crate::block::CompressError> {
+        // Only reached for the non-`Fast` modes, so `ultra_engine()` is always `Some`.
+        let (favor, finder) = self
+            .ultra_mode
+            .ultra_engine()
+            .expect("compress_current_block_ultra called in Fast mode");
+        let src_len = self.src_end - self.src_start;
+        let dst_required_size = crate::block::compress::get_maximum_output_size(src_len);
+
+        if self.ext_dict_len == 0 {
+            let mut sink = vec_sink_for_compression(&mut self.dst, 0, 0, dst_required_size);
+            self.ultra_compressor.compress_block(
+                &self.src[..self.src_end],
+                self.src_start,
+                favor,
+                finder,
+                &mut sink,
+            )
+        } else {
+            debug_assert_eq!(self.frame_info.block_mode, BlockMode::Linked);
+            self.ultra_window.clear();
+            self.ultra_window.extend_from_slice(
+                &self.src[self.ext_dict_offset..self.ext_dict_offset + self.ext_dict_len],
+            );
+            self.ultra_window
+                .extend_from_slice(&self.src[..self.src_end]);
+            let prefix_len = self.ext_dict_len + self.src_start;
+
+            let mut sink = vec_sink_for_compression(&mut self.dst, 0, 0, dst_required_size);
+            self.ultra_compressor.compress_block(
+                &self.ultra_window,
+                prefix_len,
+                favor,
+                finder,
+                &mut sink,
+            )
+        }
     }
 }
 

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -25,6 +25,9 @@ pub(crate) mod compress;
 pub(crate) mod decompress;
 pub(crate) mod header;
 
+#[cfg(feature = "ultra")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ultra")))]
+pub use compress::CompressionMode;
 pub use compress::{AutoFinishEncoder, FrameEncoder};
 pub use decompress::FrameDecoder;
 pub use header::{BlockMode, BlockSize, FrameInfo};

--- a/tests/ultra.rs
+++ b/tests/ultra.rs
@@ -1,0 +1,401 @@
+//! Tests for the optimal-parse `ultra` block compressor.
+#![cfg(feature = "ultra")]
+
+use lz4_flex::block::{
+    compress as compress_fast, compress_into_with_mode, compress_prepend_size_with_mode,
+    compress_with_mode, decompress, decompress_size_prepended, decompress_size_prepended_with_dict,
+    decompress_with_dict, get_maximum_output_size, CompressionMode,
+};
+
+const COMPRESSION1K: &[u8] = include_bytes!("../benches/compression_1k.txt");
+const COMPRESSION34K: &[u8] = include_bytes!("../benches/compression_34k.txt");
+const COMPRESSION65K: &[u8] = include_bytes!("../benches/compression_65k.txt");
+const COMPRESSION66K_JSON: &[u8] = include_bytes!("../benches/compression_66k_JSON.txt");
+const COMPRESSION10MB: &[u8] = include_bytes!("../benches/dickens.txt");
+
+const CORPUS: &[(&str, &[u8])] = &[
+    ("1k", COMPRESSION1K),
+    ("34k", COMPRESSION34K),
+    ("65k", COMPRESSION65K),
+    ("66k_json", COMPRESSION66K_JSON),
+    ("10mb", COMPRESSION10MB),
+];
+
+/// `CompressionMode::Ultra` — the suffix-array / lz4ultra compressor (no dictionary).
+fn ultra(data: &[u8]) -> Vec<u8> {
+    compress_with_mode(data, b"", CompressionMode::Ultra)
+}
+
+/// `CompressionMode::Hc` — the lz4hc compressor (no dictionary).
+fn hc(data: &[u8]) -> Vec<u8> {
+    compress_with_mode(data, b"", CompressionMode::Hc)
+}
+
+/// Decode a raw block with the reference C lz4 implementation, to prove the bytes are spec-valid.
+fn lz4_cpp_decompress(input: &[u8], decomp_len: usize) -> Vec<u8> {
+    let mut out = vec![0u8; decomp_len];
+    let n = lzzzz::lz4::decompress(input, &mut out).expect("C lz4 failed to decode ultra block");
+    assert_eq!(n, decomp_len, "C lz4 produced wrong length");
+    out
+}
+
+/// Round-trip `input` through a given mode and verify both decoders reproduce it exactly.
+fn check_roundtrip_mode(name: &str, input: &[u8], mode: CompressionMode) {
+    let compressed = compress_with_mode(input, b"", mode);
+
+    // 1. lz4_flex's own decoder.
+    let decompressed = decompress(&compressed, input.len())
+        .unwrap_or_else(|e| panic!("[{name}/{mode:?}] lz4_flex decode failed: {e:?}"));
+    assert_eq!(
+        decompressed, input,
+        "[{name}/{mode:?}] lz4_flex roundtrip mismatch"
+    );
+
+    // 2. The reference C lz4 decoder (interoperability / spec-conformance).
+    if !input.is_empty() {
+        let cpp = lz4_cpp_decompress(&compressed, input.len());
+        assert_eq!(cpp, input, "[{name}/{mode:?}] C lz4 roundtrip mismatch");
+    }
+}
+
+/// Round-trip through both optimal-parse engines (Ultra and Hc).
+fn check_roundtrip(name: &str, input: &[u8]) {
+    check_roundtrip_mode(name, input, CompressionMode::Ultra);
+    check_roundtrip_mode(name, input, CompressionMode::Hc);
+}
+
+#[test]
+fn roundtrip_corpus() {
+    for (name, data) in CORPUS {
+        check_roundtrip(name, data);
+    }
+}
+
+#[test]
+fn ratio_beats_or_matches_fast() {
+    // Optimal parsing must not lose to the greedy/lazy parser on real data.
+    for (name, data) in CORPUS {
+        let ultra = ultra(data).len();
+        let fast = compress_fast(data).len();
+        assert!(
+            ultra <= fast,
+            "[{name}] ultra ({ultra}) should be <= fast ({fast})"
+        );
+        println!(
+            "[{name}] raw={} fast={fast} ultra={ultra} (ultra {:.1}% of fast)",
+            data.len(),
+            ultra as f64 / fast as f64 * 100.0
+        );
+    }
+}
+
+#[test]
+fn edge_cases() {
+    let cases: Vec<Vec<u8>> = vec![
+        vec![],
+        vec![0],
+        vec![42],
+        b"a".to_vec(),
+        b"ab".to_vec(),
+        b"abc".to_vec(),
+        b"abcd".to_vec(),
+        b"hello".to_vec(),
+        b"Hello people, what's up?".to_vec(), // < 13 bytes path exercised by shorter ones above
+        vec![7u8; 1],
+        vec![7u8; 12],
+        vec![7u8; 13],
+        vec![7u8; 1000],    // highly repetitive
+        vec![0u8; 100_000], // long run -> long matches / varlen lengths
+        b"aaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbaaaaaaaaaaaaaaaa".to_vec(),
+    ];
+    for (i, c) in cases.iter().enumerate() {
+        check_roundtrip(&format!("edge{i}"), c);
+    }
+}
+
+#[test]
+fn incompressible_random() {
+    // Deterministic pseudo-random (xorshift) so the test is reproducible.
+    let mut state: u64 = 0x1234_5678_9abc_def0;
+    let mut next = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    for &len in &[1usize, 100, 1000, 50_000] {
+        let data: Vec<u8> = (0..len).map(|_| (next() & 0xff) as u8).collect();
+        check_roundtrip(&format!("rand{len}"), &data);
+    }
+}
+
+#[test]
+fn prepend_size_roundtrip() {
+    for (name, data) in CORPUS {
+        for mode in [CompressionMode::Ultra, CompressionMode::Hc] {
+            let compressed = compress_prepend_size_with_mode(data, b"", mode);
+            let out = decompress_size_prepended(&compressed).unwrap();
+            assert_eq!(
+                &out, data,
+                "[{name}/{mode:?}] prepend-size roundtrip mismatch"
+            );
+        }
+    }
+}
+
+#[test]
+fn compress_into_roundtrip() {
+    for (name, data) in CORPUS {
+        let mut buf = vec![0u8; get_maximum_output_size(data.len())];
+
+        // Both engines, no dictionary.
+        for mode in [CompressionMode::Ultra, CompressionMode::Hc] {
+            let n = compress_into_with_mode(data, &mut buf, b"", mode).unwrap();
+            assert_eq!(
+                decompress(&buf[..n], data.len()).unwrap(),
+                *data,
+                "[{name}/{mode:?}] into"
+            );
+        }
+
+        // With a dictionary (first half as dict, compress the second half).
+        if data.len() >= 64 {
+            let (dict, body) = data.split_at(data.len() / 2);
+            let mut dbuf = vec![0u8; get_maximum_output_size(body.len())];
+            let n = compress_into_with_mode(body, &mut dbuf, dict, CompressionMode::Ultra).unwrap();
+            assert_eq!(
+                decompress_with_dict(&dbuf[..n], body.len(), dict).unwrap(),
+                body,
+                "[{name}] into_with_dict"
+            );
+        }
+    }
+}
+
+#[test]
+fn compress_into_too_small_errors() {
+    let data = COMPRESSION34K;
+    let mut tiny = vec![0u8; 8];
+    assert!(compress_into_with_mode(data, &mut tiny, b"", CompressionMode::Ultra).is_err());
+    assert!(compress_into_with_mode(data, &mut tiny, b"", CompressionMode::Hc).is_err());
+}
+
+#[test]
+fn with_dict_roundtrip() {
+    // Use the first half as a dictionary, compress the second half against it.
+    for (name, data) in CORPUS {
+        if data.len() < 64 {
+            continue;
+        }
+        let (dict, body) = data.split_at(data.len() / 2);
+
+        for mode in [CompressionMode::Ultra, CompressionMode::Hc] {
+            let compressed = compress_with_mode(body, dict, mode);
+            let out = decompress_with_dict(&compressed, body.len(), dict).unwrap();
+            assert_eq!(&out, body, "[{name}/{mode:?}] with-dict roundtrip mismatch");
+
+            let compressed = compress_prepend_size_with_mode(body, dict, mode);
+            let out = decompress_size_prepended_with_dict(&compressed, dict).unwrap();
+            assert_eq!(
+                &out, body,
+                "[{name}/{mode:?}] with-dict prepend-size roundtrip mismatch"
+            );
+        }
+    }
+}
+
+#[cfg(feature = "frame")]
+mod frame_ultra {
+    use super::*;
+    use lz4_flex::frame::{BlockMode, FrameDecoder, FrameEncoder, FrameInfo};
+    use std::io::{Read, Write};
+
+    fn frame_compress_mode(data: &[u8], block_mode: BlockMode, mode: CompressionMode) -> Vec<u8> {
+        let mut fi = FrameInfo::new();
+        fi.block_mode = block_mode;
+        fi.block_size = lz4_flex::frame::BlockSize::Max64KB; // small blocks -> exercise linking
+        let mut enc = FrameEncoder::with_frame_info(fi, Vec::new());
+        enc.set_compression_mode(mode);
+        enc.write_all(data).unwrap();
+        enc.finish().unwrap()
+    }
+
+    fn flex_frame_decompress(compressed: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        FrameDecoder::new(compressed).read_to_end(&mut out).unwrap();
+        out
+    }
+
+    fn cpp_frame_decompress(compressed: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        lzzzz::lz4f::decompress_to_vec(compressed, &mut out).unwrap();
+        out
+    }
+
+    #[test]
+    fn all_modes_roundtrip_independent_and_linked() {
+        // Every mode must round-trip in both block modes, through both decoders.
+        // Linked + Hc is the first exercise of the lz4hc with-prefix path.
+        for (name, data) in CORPUS {
+            for block_mode in [BlockMode::Independent, BlockMode::Linked] {
+                for mode in [CompressionMode::Ultra, CompressionMode::Hc] {
+                    let compressed = frame_compress_mode(data, block_mode, mode);
+                    assert_eq!(
+                        &flex_frame_decompress(&compressed),
+                        data,
+                        "[{name}/{block_mode:?}/{mode:?}] flex frame roundtrip mismatch"
+                    );
+                    assert_eq!(
+                        &cpp_frame_decompress(&compressed),
+                        data,
+                        "[{name}/{block_mode:?}/{mode:?}] C lz4 frame roundtrip mismatch"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn frame_ultra_beats_fast() {
+        for (name, data) in CORPUS {
+            let ultra = frame_compress_mode(data, BlockMode::Linked, CompressionMode::Ultra).len();
+            let fast = frame_compress_mode(data, BlockMode::Linked, CompressionMode::Fast).len();
+            assert!(
+                ultra <= fast,
+                "[{name}] ultra frame ({ultra}) should be <= fast frame ({fast})"
+            );
+            println!("[{name}] fast_frame={fast} ultra_frame={ultra}");
+        }
+    }
+
+    #[test]
+    fn multi_write_small_chunks() {
+        // Feed the encoder in small pieces to exercise block boundaries / linked rotation.
+        let data = COMPRESSION65K;
+        for mode in [CompressionMode::Ultra, CompressionMode::Hc] {
+            let mut fi = FrameInfo::new();
+            fi.block_mode = BlockMode::Linked;
+            fi.block_size = lz4_flex::frame::BlockSize::Max64KB;
+            let mut enc = FrameEncoder::with_frame_info(fi, Vec::new());
+            enc.set_compression_mode(mode);
+            for chunk in data.chunks(1000) {
+                enc.write_all(chunk).unwrap();
+            }
+            let compressed = enc.finish().unwrap();
+            assert_eq!(flex_frame_decompress(&compressed), data, "{mode:?}");
+            assert_eq!(cpp_frame_decompress(&compressed), data, "{mode:?}");
+        }
+    }
+}
+
+mod fuzz {
+    use super::*;
+    use proptest::prelude::*;
+
+    // Plain asserts (not prop_assert!) so this shared body can be reused across strategies;
+    // proptest still catches the panic and shrinks the failing input. Correctness only: the
+    // decode-speed-favouring Ultra path is not guaranteed to beat the greedy parser on small
+    // adversarial inputs, so we don't assert a ratio bound here (see `ratio_beats_or_matches_fast`).
+    fn roundtrip(data: &[u8]) {
+        for mode in [CompressionMode::Ultra, CompressionMode::Hc] {
+            let compressed = compress_with_mode(data, b"", mode);
+            let out = decompress(&compressed, data.len()).unwrap();
+            assert_eq!(out, data, "{mode:?} lz4_flex roundtrip mismatch");
+            // Spec-conformance against the C decoder.
+            if !data.is_empty() {
+                let mut cpp = vec![0u8; data.len()];
+                let n = lzzzz::lz4::decompress(&compressed, &mut cpp).unwrap();
+                assert!(
+                    n == data.len() && cpp == data,
+                    "{mode:?} C lz4 roundtrip mismatch"
+                );
+            }
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 400, ..ProptestConfig::default() })]
+
+        // Small alphabet -> lots of matches: stresses the match finder, DP and command-count join.
+        #[test]
+        #[cfg_attr(miri, ignore)]
+        fn repetitive(data in proptest::collection::vec(0u8..6, 0..8000usize)) {
+            roundtrip(&data);
+        }
+
+        // Full byte range, including incompressible stretches.
+        #[test]
+        #[cfg_attr(miri, ignore)]
+        fn arbitrary(data in proptest::collection::vec(any::<u8>(), 0..4000usize)) {
+            roundtrip(&data);
+        }
+    }
+}
+
+/// The lz4hc engine ([`CompressionMode::Hc`]) is **byte-identical** to the C `lz4hc -12` reference on
+/// the corpus — the strongest possible validation that the lz4hc port is faithful. (It uses the
+/// ratio-favouring price model, matching lz4hc-12's own default, unlike the decode-favouring Ultra.)
+#[test]
+fn hc_byte_identical_to_c_lz4hc() {
+    for (name, data) in CORPUS {
+        let ours = hc(data);
+        let mut theirs = Vec::new();
+        lzzzz::lz4_hc::compress_to_vec(data, &mut theirs, lzzzz::lz4_hc::CLEVEL_MAX).unwrap();
+        assert_eq!(
+            ours.len(),
+            theirs.len(),
+            "[{name}] Hc size differs from C lz4hc-12"
+        );
+        assert!(
+            ours == theirs,
+            "[{name}] Hc output differs from C lz4hc-12 (same size)"
+        );
+    }
+}
+
+/// The Ultra (suffix-array / lz4ultra) and Hc (lz4hc) engines agree on ratio within a small margin
+/// (they can differ a little either way — the suffix array caps match length, lz4hc prices
+/// differently, and Ultra favours decode speed). Both round-trip.
+#[test]
+fn ultra_and_hc_agree_closely() {
+    for (name, data) in CORPUS {
+        let def = ultra(data);
+        let fast = hc(data);
+        assert_eq!(
+            decompress(&def, data.len()).unwrap(),
+            *data,
+            "[{name}] ultra roundtrip"
+        );
+        assert_eq!(
+            decompress(&fast, data.len()).unwrap(),
+            *data,
+            "[{name}] hc roundtrip"
+        );
+        let tol = def.len() / 16 + 64;
+        assert!(
+            def.len() <= fast.len() + tol && fast.len() <= def.len() + tol,
+            "[{name}] ultra {} and hc {} diverge too much",
+            def.len(),
+            fast.len()
+        );
+    }
+}
+
+mod fuzz_finders {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 300, ..ProptestConfig::default() })]
+
+        // Both engines must produce valid, correctly-decoding output on arbitrary repetitive data.
+        #[test]
+        #[cfg_attr(miri, ignore)]
+        fn both_engines_roundtrip(data in proptest::collection::vec(0u8..8, 0..6000usize)) {
+            let def = compress_with_mode(&data, b"", CompressionMode::Ultra);
+            let fast = compress_with_mode(&data, b"", CompressionMode::Hc);
+            prop_assert_eq!(decompress(&def, data.len()).unwrap(), data.clone());
+            prop_assert_eq!(decompress(&fast, data.len()).unwrap(), data);
+        }
+    }
+}


### PR DESCRIPTION
A pure-Rust, optimal-parse block compressor behind the off-by-default `ultra` feature, plus a crate-wide decoder speedup. Output is a standard LZ4 block, decodable by any LZ4 implementation. Ported from https://github.com/emmanuel-marty/lz4ultra

Engines are selected with `CompressionMode` (shared by the block and frame APIs):
- `Fast`, the existing greedy/lazy compressor (unchanged default).
- `Ultra`, a suffix array (SA-IS) + LCP-interval match finder feeding a backward optimal-parse DP. Best ratio, decode-optimised stream.
- `HC`, a hash-chain match finder with chain-swapping + a price-based optimal parser; output matches `lz4hc -12`. Fast, low memory.

Block API: `compress_with_mode`, `compress_prepend_size_with_mode`, `compress_into_with_mode` (positional dictionary, mirroring the `compress*` family). Frame API: `FrameEncoder::set_compression_mode`.

Decoder: overlapping (period < length) copies now grow by doubling the valid prefix with memmove/memcpy instead of byte-by-byte, O(log n) copies — ~10-20x on run/periodic data, text unchanged. Validated under miri and against the C decoder.

no_std + alloc; the ultra module is `forbid(unsafe_code)` under `safe-encode`. CI builds/tests the feature across the matrix and adds a miri job for the unsafe overlap copy. Covered by round-trip, ratio-parity, and byte-identical-to-`lz4hc -12` tests.