### PR TITLE
Remove redundant casts

### DIFF
--- a/src/block/decompress_safe.rs
+++ b/src/block/decompress_safe.rs
@@ -186,7 +186,7 @@ pub(crate) fn decompress_internal<const USE_DICT: bool, S: Sink>(
             if literal_length == 15 {
                 // The literal_length length took the maximal value, indicating that there is more
                 // than 15 literal_length bytes. We read the extra integer.
-                literal_length += read_integer(input, &mut input_pos)? as usize;
+                literal_length += read_integer(input, &mut input_pos)?;
             }
 
             if literal_length > input.len() - input_pos {
@@ -222,7 +222,7 @@ pub(crate) fn decompress_internal<const USE_DICT: bool, S: Sink>(
         if match_length == MINMATCH + 15 {
             // The match length took the maximal value, indicating that there is more bytes. We
             // read the extra integer.
-            match_length += read_integer(input, &mut input_pos)? as usize;
+            match_length += read_integer(input, &mut input_pos)?;
         }
 
         // could be skipped with unchecked-decode


### PR DESCRIPTION
I believe these casts can be safely removed, as the source type is already the target type.

For reference, these changes were found by an optimizer developed as a research project.

CC @nunoplopes